### PR TITLE
Changed type for "job" column from text to blob

### DIFF
--- a/src/db/migrations/m0001_queue.php
+++ b/src/db/migrations/m0001_queue.php
@@ -19,7 +19,7 @@ class m0001_queue extends Migration
         $this->createTable($this->tableName, [
             'id' => $this->primaryKey(),
             'channel' => $this->string()->notNull(),
-            'job' => $this->text()->notNull(),
+            'job' => $this->blob()->notNull(),
             'created_at' => $this->integer()->notNull(),
             'started_at' => $this->integer(),
             'finished_at' => $this->integer(),


### PR DESCRIPTION
There is a problem with serialization and `text` data type, described in https://github.com/yiisoft/yii2/issues/12681

This PR fixes the aforementioned problem