### PR TITLE
fix redis Queue class namespace

### DIFF
--- a/docs/guide/driver-redis.md
+++ b/docs/guide/driver-redis.md
@@ -14,7 +14,7 @@ return [
     ],
     'components' => [
         'queue' => [
-            'class' => \zhuravljov\yii\queue\driver\redis\Queue::class,
+            'class' => \zhuravljov\yii\queue\redis\Queue::class,
             'redis' => 'redis', // connection ID
             'channel' => 'queue', // queue channel
         ],


### PR DESCRIPTION
Hi,
I think, there is typo in documentation,
should it be \zhuravljov\yii\queue\redis\Queue now?