### PR TITLE
Queue messages may be deleted by other workers.

### DIFF
--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -102,9 +102,10 @@ class Queue extends CliQueue
         }
 
         $payload = $this->redis->hget("$this->channel.messages", $id);
-        if(!$payload) {
+        if (!$payload) {
             return null;
         }
+        
         list($ttr, $message) = explode(';', $payload, 2);
         $this->redis->zadd("$this->channel.reserved", time() + $ttr, $id);
         $attempt = $this->redis->hincrby("$this->channel.attempts", $id, 1);

--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -102,6 +102,9 @@ class Queue extends CliQueue
         }
 
         $payload = $this->redis->hget("$this->channel.messages", $id);
+        if(!$payload) {
+            return null;
+        }
         list($ttr, $message) = explode(';', $payload, 2);
         $this->redis->zadd("$this->channel.reserved", time() + $ttr, $id);
         $attempt = $this->redis->hincrby("$this->channel.attempts", $id, 1);


### PR DESCRIPTION
The queue messages may be deleted by other workers when running more than one worker.This will cause queue process throw an exception about 'Undefined offset' error.