### PR TITLE
Queue's channel message possible be deleted by other workers.

### DIFF
--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -102,6 +102,10 @@ class Queue extends CliQueue
         }
 
         $payload = $this->redis->hget("$this->channel.messages", $id);
+        if (!$payload) {
+            return null;
+        }
+        
         list($ttr, $message) = explode(';', $payload, 2);
         $this->redis->zadd("$this->channel.reserved", time() + $ttr, $id);
         $attempt = $this->redis->hincrby("$this->channel.attempts", $id, 1);


### PR DESCRIPTION
When running many workers on one channel and  same job runs more than once (retry) , like job throws some exception error, the job message possible be deleted by other workers.  When reserve get an empty payload from queue  will cause an exception error in `list`.