### PR TITLE
Implementation of aws SQS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
             "yii\\queue\\file\\": "src/drivers/file",
             "yii\\queue\\gearman\\": "src/drivers/gearman",
             "yii\\queue\\redis\\": "src/drivers/redis",
-            "yii\\queue\\sync\\": "src/drivers/sync"
+            "yii\\queue\\sync\\": "src/drivers/sync",
+            "yii\\queue\\sqs\\": "src/drivers/sqs"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.10",
+        "aws/aws-sdk-php": ">=2.4",
         "symfony/process": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,17 @@
 {
-    "name": "yiisoft/yii2-queue",
-    "description": "Yii2 Queue Extension which supported DB, Redis, RabbitMQ, Beanstalk and Gearman",
+    "name": "manoj-malviya/yii2-queue",
+    "description": "Yii2 Queue Extension which supported DB, Redis, RabbitMQ, Beanstalk, SQS and Gearman",
     "type": "yii2-extension",
-    "keywords": ["yii", "queue", "async", "gii", "db", "redis", "rabbitmq", "beanstalk", "gearman"],
+    "keywords": ["yii", "queue", "async", "gii", "db", "redis", "rabbitmq", "beanstalk", "gearman", "sqs"],
     "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Roman Zhuravlev",
             "email": "zhuravljov@gmail.com"
+        },
+        {
+            "name": "Manoj Malviya",
+            "email": "manojm@girnarsoft.com"
         }
     ],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,6 @@
         {
             "name": "Roman Zhuravlev",
             "email": "zhuravljov@gmail.com"
-        },
-        {
-            "name": "Manoj Malviya",
-            "email": "manojm@girnarsoft.com"
         }
     ],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "manoj-malviya/yii2-queue",
+    "name": "manoj-malviya/yii-2-queue",
     "description": "Yii2 Queue Extension which supported DB, Redis, RabbitMQ, Beanstalk, SQS and Gearman",
     "type": "yii2-extension",
     "keywords": ["yii", "queue", "async", "gii", "db", "redis", "rabbitmq", "beanstalk", "gearman", "sqs"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "manoj-malviya/yii-2-queue",
+    "name": "yiisoft/yii2-queue",
     "description": "Yii2 Queue Extension which supported DB, Redis, RabbitMQ, Beanstalk, SQS and Gearman",
     "type": "yii2-extension",
     "keywords": ["yii", "queue", "async", "gii", "db", "redis", "rabbitmq", "beanstalk", "gearman", "sqs"],

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.10",
-        "aws/aws-sdk-php": ">=2.4",
         "symfony/process": "*"
     },
     "require-dev": {
@@ -32,14 +31,16 @@
         "jeremeamia/superclosure": "*",
         "yiisoft/yii2-debug": "*",
         "yiisoft/yii2-gii": "*",
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "~4.4",
+        "aws/aws-sdk-php": ">=2.4"
     },
     "suggest": {
         "ext-pcntl": "Need for process signals.",
         "yiisoft/yii2-redis": "Need for Redis queue.",
         "pda/pheanstalk": "Need for Beanstalk queue.",
         "php-amqplib/php-amqplib": "Need for AMQP queue.",
-        "ext-gearman": "Need for Gearman queue."
+        "ext-gearman": "Need for Gearman queue.",
+        "aws/aws-sdk-php": "Need for aws SQS."
     },
     "autoload": {
         "psr-4": {

--- a/src/drivers/sqs/Command.php
+++ b/src/drivers/sqs/Command.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\queue\sqs;
+
+use yii\queue\cli\Command as CliCommand;
+
+/**
+ * Manages application gearman-queue.
+ *
+ * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ */
+class Command extends CliCommand
+{
+    /**
+     * @var Queue
+     */
+    public $queue;
+
+    /**
+     * Runs all jobs from gearman-queue.
+     * It can be used as cron job.
+     */
+    public function actionRun()
+    {
+        $this->queue->run();
+    }
+
+    /**
+     * Listens gearman-queue and runs new jobs.
+     * It can be used as demon process.
+     */
+    public function actionListen()
+    {
+        $this->queue->listen();
+    }
+}

--- a/src/drivers/sqs/Command.php
+++ b/src/drivers/sqs/Command.php
@@ -10,9 +10,9 @@ namespace yii\queue\sqs;
 use yii\queue\cli\Command as CliCommand;
 
 /**
- * Manages application gearman-queue.
+ * Manages application aws sqs-queue.
  *
- * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ * @author Manoj Malviya <manojm@girnarsoft.com>
  */
 class Command extends CliCommand
 {
@@ -22,7 +22,7 @@ class Command extends CliCommand
     public $queue;
 
     /**
-     * Runs all jobs from gearman-queue.
+     * Runs all jobs from sqs.
      * It can be used as cron job.
      */
     public function actionRun()
@@ -31,7 +31,7 @@ class Command extends CliCommand
     }
 
     /**
-     * Listens gearman-queue and runs new jobs.
+     * Listens sqs and runs new jobs.
      * It can be used as demon process.
      */
     public function actionListen()

--- a/src/drivers/sqs/Queue.php
+++ b/src/drivers/sqs/Queue.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace yii\queue\sqs;
+
+use yii\base\NotSupportedException;
+use yii\queue\cli\Queue as CliQueue;
+use yii\queue\cli\Signal;
+use \Aws\Sqs\SqsClient;
+
+/**
+ * SQS Queue
+ *
+ * @author Manoj Malviya <manojm@girnarsoft.com>
+ */
+class Queue extends CliQueue
+{
+    /**
+     * The SQS url.
+     * @var string
+     */
+    public $url;
+
+    public $key = '';
+    public $secret = '';
+    public $region = '';
+    public $version = 'latest';
+
+    /**
+     * @var string command class name
+     */
+    public $commandClass = Command::class;
+
+    /**
+     * @inheritdoc
+     */
+     public function init()
+     {
+         parent::init();
+     }
+
+    /**
+     * Runs all jobs from gearman-queue.
+     */
+    public function run()
+    {
+        while (!Signal::isExit() && ($payload = $this->getPayload())) {
+            list($ttr, $message) = explode(';', $payload->workload(), 2);
+            if($this->handleMessage(null, $message, $ttr, 1))
+            {
+                $this->release($payload);
+            }
+        }
+    }
+
+    /**
+     * Listens to get new jobs.
+     */
+    public function listen()
+    {
+        $this->run();        
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function pushMessage($message, $ttr, $delay, $priority)
+    {
+        if ($priority)
+        {
+            throw new NotSupportedException('Priority is not supported in this driver');
+        }
+
+        $model = $this->getClient()->sendMessage([
+            'DelaySeconds' => $delay,
+            'QueueUrl' => $this->url,
+            'MessageBody' => "$ttr;message",
+        ]);
+
+        if ($model !== null) {
+            return $model['MessageId'];
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function status($id)
+    {
+        $status = $this->getClient()->jobStatus($id);
+        if ($status[0] && !$status[1]) {
+            return self::STATUS_WAITING;
+        } elseif ($status[0] && $status[1]) {
+            return self::STATUS_RESERVED;
+        } else {
+            return self::STATUS_DONE;
+        }
+    }
+
+    /**
+     * @return \Aws\Sqs\SqsClient
+     */
+    protected function getClient()
+    {
+        if (!$this->_client) {
+            $this->_client = SqsClient::factory($this->config);
+
+        }
+        return $this->_client;
+    }
+
+    private $_client;
+
+    private function getPayload()
+    {
+        $payload = $this->getClient()->receiveMessage([
+            'QueueUrl' => $this->url,
+            'AttributeNames' => ['ApproximateReceiveCount'],
+            'MaxNumberOfMessages' => 1,
+        ]);
+
+        return $payload;
+    }
+
+    private function release()
+    {
+        if (!empty($job->header['ReceiptHandle'])) {
+            $receiptHandle = $job->header['ReceiptHandle'];
+            $response = $this->getClient()->deleteMessage([
+                'QueueUrl'      => $this->url,
+                'ReceiptHandle' => $receiptHandle,
+            ]);
+
+            return $response !== null;
+        }
+
+        return false;
+    }
+}

--- a/src/drivers/sqs/Queue.php
+++ b/src/drivers/sqs/Queue.php
@@ -16,14 +16,38 @@ use Aws\Credentials\CredentialProvider;
 class Queue extends CliQueue
 {
     /**
+    * @var SqsClient
+    */
+    private $_client;
+
+    /**
      * The SQS url.
      * @var string
      */
     public $url;
 
+    /**
+     * aws access key
+     * @var string
+     */
     public $key = '';
+
+    /**
+     * aws secret
+     * @var string
+     */
     public $secret = '';
+
+    /**
+     * region where queue is hosted.
+     * @var string
+     */
     public $region = '';
+
+    /**
+     * API version
+     * @var string
+     */
     public $version = 'latest';
 
     /**
@@ -49,8 +73,7 @@ class Queue extends CliQueue
 
             $this->reserve($payload, $ttr); //reserve it so it is not visible to another worker till ttr
 
-            if($this->handleMessage(null, $message, $ttr, 1))
-            {
+            if ($this->handleMessage(null, $message, $ttr, 1)) {
                 //if handled then remove from queue
                 $this->release($payload);
             }
@@ -70,8 +93,7 @@ class Queue extends CliQueue
      */
     protected function pushMessage($message, $ttr, $delay, $priority)
     {
-        if ($priority)
-        {
+        if ($priority) {
             throw new NotSupportedException('Priority is not supported in this driver');
         }
 
@@ -101,14 +123,13 @@ class Queue extends CliQueue
      */
     protected function getClient()
     {
-        if ($this->key && $this->secret) 
-        {
+        if ($this->key && $this->secret) {
             $provider = [
                 'key'    => $this->key, 
                 'secret' => $this->secret
             ];
         } else {
-            // use default provider if no key and secret key passed
+            // use default provider if no key and secret passed
             //see - http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/credentials.html#credential-profiles
             $provider = CredentialProvider::defaultProvider();
         }
@@ -126,8 +147,9 @@ class Queue extends CliQueue
         return $this->_client;
     }
 
-    private $_client;
-
+    /**
+    *
+    */
     private function getPayload()
     {
         $payload = $this->getClient()->receiveMessage([
@@ -137,17 +159,19 @@ class Queue extends CliQueue
         ]);
 
         $payload = $payload['Messages'];
-        if ($payload){
+        if ($payload) {
             return array_pop($payload);
         }
 
         return null;
-        
     }
 
     /**
     * Set the visibilty to reserve message
     * So that no other worker can see this message
+    *
+    * @param array $payload
+    * @param int $ttr  
     */
     private function reserve($payload, $ttr)
     {
@@ -161,6 +185,9 @@ class Queue extends CliQueue
 
     /**
     * Mark the message as handled
+    *
+    * @param array $payload
+    * @return boolean
     */
     private function release($payload)
     {

--- a/src/drivers/sqs/Queue.php
+++ b/src/drivers/sqs/Queue.php
@@ -178,7 +178,7 @@ class Queue extends CliQueue
         $receiptHandle = $payload['ReceiptHandle'];
         $this->getClient()->changeMessageVisibility(array(
             'QueueUrl' => $this->url,
-            'ReceiptHandle' => $queue_handle,
+            'ReceiptHandle' => $receiptHandle,
             'VisibilityTimeout' => $ttr
         ));
     }


### PR DESCRIPTION
Basic implementation of aws SQS. So far implements 2 authentication methods

Directly embedding key/secret in config
```php
'queue' => [
            'class' => \yii\queue\sqs\Queue::class,
            'url' => '<sqs url>',
            'key' => '<key>',
            'secret' => '<secret>',
            'region' => '<region>',
            'commandClass' => console\controllers\QueueController::class
        ],
```
if key and secret is not preset it will use Default CredensialProvider 
see http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/credentials.html#credential-profiles.


Please review and provide feedback.