### PR TITLE
catch all \Throwable's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii2 Queue Extension Change Log
 - Enh #116: Add Chinese Guide (kids-return)
 - Enh #97: Queue::status is public method (zhuravljov)
 - Bug #98: Fixed timeout error handler (zhuravljov)
+- Enh #137: All throwable errors caused by jobs are now caught (brandonkelly)
 
 ## 2.0.0
 

--- a/src/ErrorEvent.php
+++ b/src/ErrorEvent.php
@@ -15,7 +15,7 @@ namespace yii\queue;
 class ErrorEvent extends ExecEvent
 {
     /**
-     * @var \Exception
+     * @var \Exception|\Throwable
      */
     public $error;
     /**

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -190,6 +190,8 @@ abstract class Queue extends Component
             $event->job->execute($this);
         } catch (\Exception $error) {
             return $this->handleError($event->id, $event->job, $event->ttr, $event->attempt, $error);
+        } catch (\Throwable $error) {
+            return $this->handleError($event->id, $event->job, $event->ttr, $event->attempt, $error);
         }
         $this->trigger(self::EVENT_AFTER_EXEC, $event);
 
@@ -201,7 +203,7 @@ abstract class Queue extends Component
      * @param Job $job
      * @param int $ttr
      * @param int $attempt
-     * @param \Exception $error
+     * @param \Exception|\Throwable $error
      * @return bool
      * @internal
      */

--- a/src/RetryableJob.php
+++ b/src/RetryableJob.php
@@ -21,7 +21,7 @@ interface RetryableJob extends Job
 
     /**
      * @param int $attempt number
-     * @param \Exception $error from last execute of the job
+     * @param \Exception|\Throwable $error from last execute of the job
      * @return bool
      */
     public function canRetry($attempt, $error);


### PR DESCRIPTION
This PR updates `yii\queue\Queue::handleMessage()` to catch all `Throwable`s thrown during job execution, rather than just `\Exception`s, preventing [`TypeError`s](http://php.net/manual/en/class.typeerror.php) and other non-exception throwables from causing the whole PHP process to end unexpectedly.

`Exception`s are still explicitly caught as well for servers running PHP 5.6, as `Throwable` wasn’t introduced until PHP 7 (similar to `yii\db\Migration::up()` and `down()`).

I’ve also updated the relevant `\Exception` docblock type declarations to `\Exception|\Throwable`. I decided not to change them to just `\Throwable` (which does include `Exception`s) because IDEs set to interpret PHP code as PHP 5.6 wouldn’t recognize it.