### PR TITLE
Add AMQP interop based driver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
 
 matrix:
+  include:
+    - php: 5.5
+      env: EXCLUDE_AMQP_INTEROP=true
   fast_finish: true
+
 
 services:
   - mysql
@@ -31,6 +34,7 @@ before_install:
 install:
   - travis_retry composer self-update && composer --version
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - if [ "$EXCLUDE_AMQP_INTEROP" = true ]; then travis_retry composer remove "enqueue/amqp-lib" "enqueue/amqp-tools" --dev --no-interaction  --no-update; fi
   - travis_retry composer install --prefer-dist --no-interaction
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ Yii2 Queue Extension Change Log
 2.0.2 under development
 -----------------------
 
-- no changes in this release.
-
+- Enh: Add Amqp Interop driver (makasim)
 
 ## 2.0.1, November 13, 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.0.2 under development
 -----------------------
 
-- Enh: Add Amqp Interop driver (makasim)
+- Enh: #158 Add Amqp Interop driver (makasim)
 
 ## 2.0.1, November 13, 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.0.2 under development
 -----------------------
 
-- Enh: #158 Add Amqp Interop driver (makasim)
+- Enh #158: Add Amqp Interop driver (makasim)
 
 ## 2.0.1, November 13, 2017
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,11 @@ Upgrading Instructions
 This file contains the upgrade notes. These notes highlight changes that could break your
 application when you upgrade the package from one version to another.
 
+Upgrade from 2.0.1 to 2.0.2
+---------------------------
+
+* The [Amqp driver](docs/guide/driver-amqp.md) has been deprecated. You can still use till 3.0 release where it will be removed. It is advised to migrate to [Amqp Interop]((docs/guide/driver-amqp-interop.md)).  
+
 Upgrade from 2.0.0 to 2.0.1
 ---------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "psr-4": {
             "yii\\queue\\": "src",
             "yii\\queue\\amqp\\": "src/drivers/amqp",
+            "yii\\queue\\amqp_interop\\": "src/drivers/amqp_interop",
             "yii\\queue\\beanstalk\\": "src/drivers/beanstalk",
             "yii\\queue\\db\\": "src/drivers/db",
             "yii\\queue\\file\\": "src/drivers/file",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require-dev": {
         "yiisoft/yii2-redis": "*",
         "php-amqplib/php-amqplib": "*",
+        "enqueue/amqp-lib": "^0.8",
         "pda/pheanstalk": "*",
         "jeremeamia/superclosure": "*",
         "yiisoft/yii2-debug": "*",
@@ -34,6 +35,7 @@
         "yiisoft/yii2-redis": "Need for Redis queue.",
         "pda/pheanstalk": "Need for Beanstalk queue.",
         "php-amqplib/php-amqplib": "Need for AMQP queue.",
+        "enqueue/amqp-lib": "Need for AMQP interop queue.",
         "ext-gearman": "Need for Gearman queue."
     },
     "autoload": {

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -18,7 +18,7 @@ Queue Drivers
 * [Db](driver-db.md)
 * [Redis](driver-redis.md)
 * [RabbitMQ](driver-amqp.md)
-* [AMQP Interop)](driver-amqp-interop.md)
+* [AMQP Interop](driver-amqp-interop.md)
 * [Beanstalk](driver-beanstalk.md)
 * [Gearman](driver-gearman.md)
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -18,6 +18,7 @@ Queue Drivers
 * [Db](driver-db.md)
 * [Redis](driver-redis.md)
 * [RabbitMQ](driver-amqp.md)
+* [AMQP Interop)](driver-amqp-interop.md)
 * [Beanstalk](driver-beanstalk.md)
 * [Gearman](driver-gearman.md)
 

--- a/docs/guide/driver-amqp-interop.md
+++ b/docs/guide/driver-amqp-interop.md
@@ -40,7 +40,7 @@ return [
             // or
             'dsn' => 'amqp://guest:guest@localhost:5672/%2F',
             
-            // or (same as above
+            // or, same as above
             'dsn' => 'amqp:',
         ],
     ],

--- a/docs/guide/driver-amqp-interop.md
+++ b/docs/guide/driver-amqp-interop.md
@@ -5,6 +5,22 @@ The driver works with RabbitMQ queues.
 
 In order for it to work you should add any [amqp interop](https://github.com/queue-interop/queue-interop#amqp-interop) compatible transport to your project, for example `enqueue/amqp-lib` package.
 
+Advantages:
+
+* It would work with any amqp interop compatible transports, such as 
+
+    * [enqueue/amqp-ext](https://github.com/php-enqueue/amqp-ext) based on [php amqp extension](https://github.com/pdezwart/php-amqp)
+    * [enqueue/amqp-lib](https://github.com/php-enqueue/amqp-lib) based on [php-amqplib/php-amqplib](https://github.com/php-amqplib/php-amqplib)
+    * [enqueue/amqp-bunny](https://github.com/php-enqueue/amqp-bunny) based on [bunny](https://github.com/jakubkulhan/bunny)
+    
+* Supports priorities
+* Supports delays
+* Supports ttr
+* Supports attempts
+* Contains new options like: vhost, connection_timeout, qos_prefetch_count and so on.
+* Supports Secure (SSL) AMQP connections.
+* An ability to set DSN like: amqp:, amqps: or amqp://user:pass@localhost:1000/vhost
+
 Configuration example:
 
 ```php

--- a/docs/guide/driver-amqp-interop.md
+++ b/docs/guide/driver-amqp-interop.md
@@ -1,11 +1,9 @@
-RabbitMQ Driver
-===============
-
-_**Note:** The driver hsa been deprecated since 2.1 will be removed in 3.0. Consider using [amqp_interop](driver-amqp-interop.md) driver instead._
+AMQP Interop 
+============
 
 The driver works with RabbitMQ queues.
 
-In order for it to work you should add `php-amqplib/php-amqplib` package to your project.
+In order for it to work you should add any [amqp interop](https://github.com/queue-interop/queue-interop#amqp-interop) compatible transport to your project, for example `enqueue/amqp-lib` package.
 
 Configuration example:
 
@@ -16,12 +14,18 @@ return [
     ],
     'components' => [
         'queue' => [
-            'class' => \yii\queue\amqp\Queue::class,
-            'host' => 'localhost',
+            'class' => \yii\queue\amqp_interop\Queue::class,
             'port' => 5672,
             'user' => 'guest',
             'password' => 'guest',
             'queueName' => 'queue',
+            'driver' => 'lib',
+            
+            // or
+            'dsn' => 'amqp://guest:guest@localhost:5672/%2F',
+            
+            // or (same as above
+            'dsn' => 'amqp:',
         ],
     ],
 ];

--- a/docs/guide/driver-amqp-interop.md
+++ b/docs/guide/driver-amqp-interop.md
@@ -9,7 +9,7 @@ Advantages:
 
 * It would work with any amqp interop compatible transports, such as 
 
-    * [enqueue/amqp-ext](https://github.com/php-enqueue/amqp-ext) based on [php amqp extension](https://github.com/pdezwart/php-amqp)
+    * [enqueue/amqp-ext](https://github.com/php-enqueue/amqp-ext) based on [PHP amqp extension](https://github.com/pdezwart/php-amqp)
     * [enqueue/amqp-lib](https://github.com/php-enqueue/amqp-lib) based on [php-amqplib/php-amqplib](https://github.com/php-amqplib/php-amqplib)
     * [enqueue/amqp-bunny](https://github.com/php-enqueue/amqp-bunny) based on [bunny](https://github.com/jakubkulhan/bunny)
     
@@ -35,7 +35,7 @@ return [
             'user' => 'guest',
             'password' => 'guest',
             'queueName' => 'queue',
-            'driver' => 'lib',
+            'driver' => yii\queue\amqp_interop\Queue::ENQUEUE_AMQP_LIB,
             
             // or
             'dsn' => 'amqp://guest:guest@localhost:5672/%2F',

--- a/docs/guide/driver-amqp.md
+++ b/docs/guide/driver-amqp.md
@@ -1,7 +1,7 @@
 RabbitMQ Driver
 ===============
 
-_**Note:** The driver provides basic support only and misses some features: delaying, priorities and others. Consider using [amqp_interop](driver-amqp-interop.md) driver which supports more features._
+__**Note:** The driver hsa been deprecated since 2.0.2 and will be removed in 3.0. Consider using [amqp_interop](driver-amqp-interop.md) driver instead._
 
 The driver works with RabbitMQ queues.
 

--- a/docs/guide/driver-amqp.md
+++ b/docs/guide/driver-amqp.md
@@ -1,7 +1,7 @@
 RabbitMQ Driver
 ===============
 
-_**Note:** The driver hsa been deprecated since 2.1 will be removed in 3.0. Consider using [amqp_interop](driver-amqp-interop.md) driver instead._
+_**Note:** The driver provides basic support only and misses some features: delaying, priorities and others. Consider using [amqp_interop](driver-amqp-interop.md) driver which supports more features._
 
 The driver works with RabbitMQ queues.
 

--- a/docs/guide/retryable.md
+++ b/docs/guide/retryable.md
@@ -88,7 +88,7 @@ priority.
 Restrictions
 ------------
 
-Full support of retryable implements for [Beanstalk], [DB], [File] and [Redis] drivers.
+Full support of retryable implements for [Beanstalk], [DB], [File], [AMQP Interop] and [Redis] drivers.
 [Sync] driver will not retry failed jobs. [Gearman] driver doesn't support of retryable.
 [RabbitMQ] has only its basic retryable support, in which an attempt number can not be got.
 
@@ -99,3 +99,4 @@ Full support of retryable implements for [Beanstalk], [DB], [File] and [Redis] d
 [Sync]: driver-sync.md
 [Gearman]: driver-gearman.md
 [RabbitMQ]: driver-amqp.md
+[AMQP Interop]: driver-amqp-interop.md

--- a/docs/guide/worker.md
+++ b/docs/guide/worker.md
@@ -34,7 +34,7 @@ file.
 For more info about Supervisor's configure and usage see [documentation](http://supervisord.org).
 
 Worker starting in daemon mode with `queue/listen` command supports [File], [Db], [Redis],
-[RabbitMQ], [Beanstalk], [Gearman] drivers. For additional options see driver guide.
+[RabbitMQ], [AMQP Interop], [Beanstalk], [Gearman] drivers. For additional options see driver guide.
 
 [File]: driver-file.md
 [Db]: driver-db.md
@@ -42,6 +42,7 @@ Worker starting in daemon mode with `queue/listen` command supports [File], [Db]
 [RabbitMQ]: driver-amqp.md
 [Beanstalk]: driver-beanstalk.md
 [Gearman]: driver-gearman.md
+[AMQP Interop]: driver-amqp-interop.md
 
 Systemd
 -------

--- a/docs/guide/worker.md
+++ b/docs/guide/worker.md
@@ -39,10 +39,10 @@ Worker starting in daemon mode with `queue/listen` command supports [File], [Db]
 [File]: driver-file.md
 [Db]: driver-db.md
 [Redis]: driver-redis.md
-[RabbitMQ]: driver-amqp.md
+[RabbitMQ (AMQP Interop)]: driver-amqp-interop.md
+[RabbitMQ (Deprecated)]: driver-amqp.md
 [Beanstalk]: driver-beanstalk.md
 [Gearman]: driver-gearman.md
-[AMQP Interop]: driver-amqp-interop.md
 
 Systemd
 -------

--- a/src/drivers/amqp/Command.php
+++ b/src/drivers/amqp/Command.php
@@ -12,6 +12,8 @@ use yii\queue\cli\Command as CliCommand;
 /**
  * Manages application amqp-queue.
  *
+ * @deprecated since 2.0.2 and will be removed in 3.0. Consider using amqp_interop driver instead
+ *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
  */
 class Command extends CliCommand

--- a/src/drivers/amqp/Command.php
+++ b/src/drivers/amqp/Command.php
@@ -10,8 +10,6 @@ namespace yii\queue\amqp;
 use yii\queue\cli\Command as CliCommand;
 
 /**
- * @deprecated since 2.1 will be removed in 3.0. Consider using amqp_interop driver instead
- *
  * Manages application amqp-queue.
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>

--- a/src/drivers/amqp/Queue.php
+++ b/src/drivers/amqp/Queue.php
@@ -18,6 +18,8 @@ use yii\queue\cli\Queue as CliQueue;
 /**
  * Amqp Queue
  *
+ * @deprecated since 2.0.2 and will be removed in 3.0. Consider using amqp_interop driver instead
+ *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
  */
 class Queue extends CliQueue

--- a/src/drivers/amqp/Queue.php
+++ b/src/drivers/amqp/Queue.php
@@ -16,8 +16,6 @@ use yii\base\NotSupportedException;
 use yii\queue\cli\Queue as CliQueue;
 
 /**
- * @deprecated since 2.1 will be removed in 3.0. Consider using amqp_interop driver instead
- *
  * Amqp Queue
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>

--- a/src/drivers/amqp/Queue.php
+++ b/src/drivers/amqp/Queue.php
@@ -16,6 +16,8 @@ use yii\base\NotSupportedException;
 use yii\queue\cli\Queue as CliQueue;
 
 /**
+ * @deprecated since 2.1 will be removed in 3.0. Consider using amqp_interop driver instead
+ *
  * Amqp Queue
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
@@ -29,6 +31,7 @@ class Queue extends CliQueue
     public $queueName = 'queue';
     public $exchangeName = 'exchange';
     public $vhost = '/';
+
     /**
      * @var string command class name
      */
@@ -42,6 +45,7 @@ class Queue extends CliQueue
      * @var AMQPChannel
      */
     protected $channel;
+
 
 
     /**

--- a/src/drivers/amqp_interop/Command.php
+++ b/src/drivers/amqp_interop/Command.php
@@ -30,12 +30,4 @@ class Command extends CliCommand
     {
         $this->queue->listen();
     }
-
-    /**
-     * Creates all required queues, topics etc
-     */
-    public function actionSetupBroker()
-    {
-        $this->queue->setupBroker();
-    }
 }

--- a/src/drivers/amqp_interop/Command.php
+++ b/src/drivers/amqp_interop/Command.php
@@ -13,6 +13,7 @@ use yii\queue\cli\Command as CliCommand;
  * Manages application amqp-queue.
  *
  * @author Maksym Kotliar <kotlyar.maksim@gmail.com>
+ * @since 2.0.2
  */
 class Command extends CliCommand
 {

--- a/src/drivers/amqp_interop/Command.php
+++ b/src/drivers/amqp_interop/Command.php
@@ -5,13 +5,11 @@
  * @license http://www.yiiframework.com/license/
  */
 
-namespace yii\queue\amqp;
+namespace yii\queue\amqp_interop;
 
 use yii\queue\cli\Command as CliCommand;
 
 /**
- * @deprecated since 2.1 will be removed in 3.0. Consider using amqp_interop driver instead
- *
  * Manages application amqp-queue.
  *
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
@@ -30,5 +28,13 @@ class Command extends CliCommand
     public function actionListen()
     {
         $this->queue->listen();
+    }
+
+    /**
+     * Creates all required queues, topics etc
+     */
+    public function actionSetupBroker()
+    {
+        $this->queue->setupBroker();
     }
 }

--- a/src/drivers/amqp_interop/Command.php
+++ b/src/drivers/amqp_interop/Command.php
@@ -12,7 +12,7 @@ use yii\queue\cli\Command as CliCommand;
 /**
  * Manages application amqp-queue.
  *
- * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ * @author Maksym Kotliar <kotlyar.maksim@gmail.com>
  */
 class Command extends CliCommand
 {

--- a/src/drivers/amqp_interop/Command.php
+++ b/src/drivers/amqp_interop/Command.php
@@ -30,4 +30,12 @@ class Command extends CliCommand
     {
         $this->queue->listen();
     }
+
+    /**
+     * Creates all required queues, topics etc
+     */
+    public function actionSetupBroker()
+    {
+        $this->queue->setupBroker();
+    }
 }

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -32,10 +32,10 @@ use yii\queue\cli\Queue as CliQueue;
  */
 class Queue extends CliQueue
 {
-    const H_ATTEMPT = 'yii-attempt';
-    const H_TTR = 'yii-ttr';
-    const H_DELAY = 'yii-delay';
-    const H_PRIORITY = 'yii-priority';
+    const ATTEMPT = 'yii-attempt';
+    const TTR = 'yii-ttr';
+    const DELAY = 'yii-delay';
+    const PRIORITY = 'yii-priority';
 
     const ENQUEUE_AMQP_LIB = 'enqueue/amqp-lib';
     const ENQUEUE_AMQP_EXT = 'enqueue/amqp-ext';
@@ -262,8 +262,8 @@ class Queue extends CliQueue
                 return true;
             }
 
-            $ttr = $message->getProperty(self::H_TTR);
-            $attempt = $message->getProperty(self::H_ATTEMPT, 1);
+            $ttr = $message->getProperty(self::TTR);
+            $attempt = $message->getProperty(self::ATTEMPT, 1);
 
             if ($this->handleMessage($message->getMessageId(), $message->getBody(), $ttr, $attempt)) {
                 $consumer->acknowledge($message);
@@ -303,18 +303,18 @@ class Queue extends CliQueue
         $message->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
         $message->setMessageId(uniqid('', true));
         $message->setTimestamp(time());
-        $message->setProperty(self::H_ATTEMPT, 1);
-        $message->setProperty(self::H_TTR, $ttr);
+        $message->setProperty(self::ATTEMPT, 1);
+        $message->setProperty(self::TTR, $ttr);
 
         $producer = $this->context->createProducer();
 
         if ($delay) {
-            $message->setProperty(self::H_DELAY, $delay);
+            $message->setProperty(self::DELAY, $delay);
             $producer->setDeliveryDelay($delay * 1000);
         }
 
         if ($priority) {
-            $message->setProperty(self::H_PRIORITY, $priority);
+            $message->setProperty(self::PRIORITY, $priority);
             $producer->setPriority($priority);
         }
 
@@ -427,11 +427,11 @@ class Queue extends CliQueue
      */
     protected function redeliver(AmqpMessage $message)
     {
-         $attempt = $message->getProperty(self::H_ATTEMPT, 1);
+         $attempt = $message->getProperty(self::ATTEMPT, 1);
 
          $newMessage = $this->context->createMessage($message->getBody(), $message->getProperties(), $message->getHeaders());
          $newMessage->setDeliveryMode($message->getDeliveryMode());
-         $newMessage->setProperty(self::H_ATTEMPT, ++$attempt);
+         $newMessage->setProperty(self::ATTEMPT, ++$attempt);
 
          $this->context->createProducer()->send(
              $this->context->createQueue($this->queueName),

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\queue\amqp_interop;
+
+use Enqueue\AmqpTools\DelayStrategyAware;
+use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
+use Enqueue\AmqpLib\AmqpConnectionFactory as AmqpLibConnectionFactory;
+use Enqueue\AmqpExt\AmqpConnectionFactory as AmqpExtConnectionFactory;
+use Enqueue\AmqpBunny\AmqpConnectionFactory as AmqpBunnyConnectionFactory;
+use Interop\Amqp\AmqpConnectionFactory;
+use Interop\Amqp\AmqpConsumer;
+use Interop\Amqp\AmqpContext;
+use Interop\Amqp\AmqpMessage;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use yii\base\Application as BaseApp;
+use yii\base\Event;
+use yii\base\NotSupportedException;
+use yii\queue\cli\Queue as CliQueue;
+
+/**
+ * Amqp Queue
+ *
+ * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ */
+class Queue extends CliQueue
+{
+    const H_ATTEMPT = 'yii-attempt';
+    const H_TTR = 'yii-ttr';
+    const H_DELAY = 'yii-delay';
+    const H_PRIORITY = 'yii-priority';
+
+    /**
+     * @var string like amqp:, amqps:, amqps://user:pass@localhost:1000/vhost
+     */
+    public $dsn = null;
+
+    /**
+     * @var string|null
+     */
+    public $host = null;
+
+    /**
+     * @var string|null
+     */
+    public $port = null;
+
+    /**
+     * @var string|null
+     */
+    public $user = null;
+
+    /**
+     * @var string|null
+     */
+    public $password = null;
+
+    /**
+     * @var string|null
+     */
+    public $vhost = null;
+
+    /**
+     * In seconds
+     *
+     * @var float|null
+     */
+    public $readTimeout = null;
+
+    /**
+     * In seconds
+     *
+     * @var float|null
+     */
+    public $writeTimeout = null;
+
+    /**
+     * In seconds
+     *
+     * @var float|null
+     */
+    public $connectionTimeout = null;
+
+    /**
+     * In seconds
+     *
+     * @var float|null
+     */
+    public $heartbeat = null;
+
+    /**
+     * @var bool|null
+     */
+    public $persisted = null;
+
+    /**
+     * @var bool|null
+     */
+    public $lazy = null;
+
+    /**
+     * @var bool|null
+     */
+    public $qosGlobal = null;
+
+    /**
+     * @var int|null
+     */
+    public $qosPrefetchSize = null;
+
+    /**
+     * @var int|null
+     */
+    public $qosPrefetchCount = null;
+
+    /**
+     * @var bool|null
+     */
+    public $sslOn = null;
+
+    /**
+     * @var bool|null
+     */
+    public $sslVerify = null;
+
+    /**
+     * @var string|null
+     */
+    public $sslCacert = null;
+
+    /**
+     * @var string|null
+     */
+    public $sslCert = null;
+
+    /**
+     * @var string|null
+     */
+    public $sslKey = null;
+
+    /**
+     * @var string
+     */
+    public $queueName = 'queue';
+
+    /**
+     * @var string
+     */
+    public $exchangeName = 'exchange';
+
+    /**
+     * @var string
+     */
+    public $driver = 'lib';
+
+    /**
+     * @var string command class name
+     */
+    public $commandClass = Command::class;
+
+    /**
+     * @var AmqpContext
+     */
+    protected $context;
+
+    /**
+     * @var string[]
+     */
+    protected $supportedDrivers = ['lib', 'ext', 'bunny'];
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+        Event::on(BaseApp::class, BaseApp::EVENT_AFTER_REQUEST, function () {
+            $this->close();
+        });
+    }
+
+    /**
+     * Listens amqp-queue and runs new jobs.
+     */
+    public function listen()
+    {
+        $this->open();
+        $this->setupBroker();
+
+        $queue = $this->context->createQueue($this->queueName);
+        $consumer = $this->context->createConsumer($queue);
+        $this->context->subscribe($consumer, function(AmqpMessage $message, AmqpConsumer $consumer) {
+            if ($message->isRedelivered()) {
+                $consumer->acknowledge($message);
+
+                $this->redeliver($message);
+
+                return true;
+            }
+
+            $ttr = $message->getProperty(self::H_TTR);
+            $attempt = $message->getProperty(self::H_ATTEMPT, 1);
+
+            if ($this->handleMessage($message->getMessageId(), $message->getBody(), $ttr, $attempt)) {
+                $consumer->acknowledge($message);
+            } else {
+                $consumer->acknowledge($message);
+
+                $this->redeliver($message);
+            }
+
+            return true;
+        });
+
+        $this->context->consume();
+    }
+
+    /**
+     * @return AmqpContext
+     */
+    public function getContext()
+    {
+        $this->open();
+
+        return $this->context;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function pushMessage($payload, $ttr, $delay, $priority)
+    {
+        $this->open();
+        $this->setupBroker();
+
+        $topic = $this->context->createTopic($this->exchangeName);
+
+        $message = $this->context->createMessage($payload);
+        $message->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
+        $message->setMessageId(uniqid('', true));
+        $message->setTimestamp(time());
+        $message->setProperty(self::H_ATTEMPT, 1);
+        $message->setProperty(self::H_TTR, $ttr);
+
+        $producer = $this->context->createProducer();
+
+        if ($delay) {
+            $message->setProperty(self::H_DELAY, $delay);
+            $producer->setDeliveryDelay($delay * 1000);
+        }
+
+        if ($priority) {
+            $message->setProperty(self::H_PRIORITY, $priority);
+            $producer->setPriority($priority);
+        }
+
+        $producer->send($topic, $message);
+
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function status($id)
+    {
+        throw new NotSupportedException('Status is not supported in the driver.');
+    }
+
+    /**
+     * Opens connection and channel
+     */
+    protected function open()
+    {
+        if ($this->context) {
+            return;
+        }
+
+        switch ($this->driver) {
+            case 'lib':
+                $connectionClass = AmqpLibConnectionFactory::class;
+
+                break;
+            case 'ext':
+                $connectionClass = AmqpExtConnectionFactory::class;
+
+                break;
+            case 'bunny':
+                $connectionClass = AmqpBunnyConnectionFactory::class;
+
+                break;
+
+            default:
+                throw new \LogicException(sprintf('The given driver "%s" is not supported. Supported are "%s"', $this->driver, implode('", "', $this->supportedDrivers)));
+        }
+
+        $config = [
+            'dsn' => $this->dsn,
+            'host' => $this->host,
+            'port' => $this->port,
+            'user' => $this->user,
+            'pass' => $this->password,
+            'vhost' => $this->vhost,
+            'read_timeout' => $this->readTimeout,
+            'write_timeout' => $this->writeTimeout,
+            'connection_timeout' => $this->connectionTimeout,
+            'heartbeat' => $this->heartbeat,
+            'persisted' => $this->persisted,
+            'lazy' => $this->lazy,
+            'qos_global' => $this->qosGlobal,
+            'qos_prefetch_size' => $this->qosPrefetchSize,
+            'qos_prefetch_count' => $this->qosPrefetchCount,
+            'ssl_on' => $this->sslOn,
+            'ssl_verify' => $this->sslVerify,
+            'ssl_cacert' => $this->sslCacert,
+            'ssl_cert' => $this->sslCert,
+            'ssl_key' => $this->sslKey,
+        ];
+
+        $config = array_filter($config, function($value) {
+            return null !== $value;
+        });
+
+        /** @var AmqpConnectionFactory $factory */
+        $factory = new $connectionClass($config);
+
+        $this->context = $factory->createContext();
+
+        if ($this->context instanceof DelayStrategyAware) {
+            $this->context->setDelayStrategy(new RabbitMqDlxDelayStrategy());
+        }
+    }
+
+    public function setupBroker()
+    {
+        $queue = $this->context->createQueue($this->queueName);
+        $queue->addFlag(AmqpQueue::FLAG_DURABLE);
+        $queue->setArguments(['x-max-priority' => 4]);
+        $this->context->declareQueue($queue);
+
+        $topic = $this->context->createTopic($this->exchangeName);
+        $topic->setType(AmqpTopic::TYPE_DIRECT);
+        $topic->addFlag(AmqpTopic::FLAG_DURABLE);
+        $this->context->declareTopic($topic);
+
+        $this->context->bind(new AmqpBind($queue, $topic));
+    }
+
+    /**
+     * Closes connection and channel
+     */
+    protected function close()
+    {
+        if (!$this->context) {
+            return;
+        }
+
+        $this->context->close();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function redeliver(AmqpMessage $message)
+    {
+         $attempt = $message->getProperty(self::H_ATTEMPT, 1);
+
+         $newMessage = $this->context->createMessage($message->getBody(), $message->getProperties(), $message->getHeaders());
+         $newMessage->setDeliveryMode($message->getDeliveryMode());
+         $newMessage->setProperty(self::H_ATTEMPT, ++$attempt);
+
+         $this->context->createProducer()->send(
+             $this->context->createQueue($this->queueName),
+             $newMessage
+         );
+     }
+}

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -249,6 +249,7 @@ class Queue extends CliQueue
     public function listen()
     {
         $this->open();
+        $this->setupBroker();
 
         $queue = $this->context->createQueue($this->queueName);
         $consumer = $this->context->createConsumer($queue);
@@ -294,6 +295,7 @@ class Queue extends CliQueue
     protected function pushMessage($payload, $ttr, $delay, $priority)
     {
         $this->open();
+        $this->setupBroker();
 
         $topic = $this->context->createTopic($this->exchangeName);
 
@@ -391,14 +393,9 @@ class Queue extends CliQueue
         if ($this->context instanceof DelayStrategyAware) {
             $this->context->setDelayStrategy(new RabbitMqDlxDelayStrategy());
         }
-
-        $this->setupBroker();
     }
 
-    /**
-     * Creates all required queues, topics etc
-     */
-    protected function setupBroker()
+    public function setupBroker()
     {
         $queue = $this->context->createQueue($this->queueName);
         $queue->addFlag(AmqpQueue::FLAG_DURABLE);

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -262,7 +262,7 @@ class Queue extends CliQueue
 
         $producer->send($topic, $message);
 
-        return null;
+        return $message->getMessageId();
     }
 
     /**

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -27,7 +27,7 @@ use yii\queue\cli\Queue as CliQueue;
 /**
  * Amqp Queue
  *
- * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ * @author Maksym Kotliar <kotlyar.maksim@gmail.com>
  */
 class Queue extends CliQueue
 {
@@ -147,7 +147,7 @@ class Queue extends CliQueue
     /**
      * @var string
      */
-    public $queueName = 'queue';
+    public $queueName = 'interop_queue';
 
     /**
      * @var string

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -403,7 +403,7 @@ class Queue extends CliQueue
         }
     }
 
-    public function setupBroker()
+    protected function setupBroker()
     {
         if ($this->setupBrokerDone) {
             return;

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -249,7 +249,6 @@ class Queue extends CliQueue
     public function listen()
     {
         $this->open();
-        $this->setupBroker();
 
         $queue = $this->context->createQueue($this->queueName);
         $consumer = $this->context->createConsumer($queue);
@@ -295,7 +294,6 @@ class Queue extends CliQueue
     protected function pushMessage($payload, $ttr, $delay, $priority)
     {
         $this->open();
-        $this->setupBroker();
 
         $topic = $this->context->createTopic($this->exchangeName);
 
@@ -393,9 +391,14 @@ class Queue extends CliQueue
         if ($this->context instanceof DelayStrategyAware) {
             $this->context->setDelayStrategy(new RabbitMqDlxDelayStrategy());
         }
+
+        $this->setupBroker();
     }
 
-    public function setupBroker()
+    /**
+     * Creates all required queues, topics etc
+     */
+    protected function setupBroker()
     {
         $queue = $this->context->createQueue($this->queueName);
         $queue->addFlag(AmqpQueue::FLAG_DURABLE);

--- a/tests/app/config/main.php
+++ b/tests/app/config/main.php
@@ -10,6 +10,7 @@ $config = [
         'pgsqlQueue',
         'redisQueue',
         'amqpQueue',
+        'amqpInteropQueue',
         'beanstalkQueue',
     ],
     'components' => [
@@ -71,6 +72,9 @@ $config = [
         ],
         'amqpQueue' => [
             'class' => \yii\queue\amqp\Queue::class,
+        ],
+        'amqpInteropQueue' => [
+            'class' => \yii\queue\amqp_interop\Queue::class,
         ],
         'beanstalkQueue' => [
             'class' => \yii\queue\beanstalk\Queue::class,

--- a/tests/app/config/main.php
+++ b/tests/app/config/main.php
@@ -75,8 +75,6 @@ $config = [
         ],
         'amqpInteropQueue' => [
             'class' => \yii\queue\amqp_interop\Queue::class,
-            'queueName' => 'queue-interop',
-            'exchangeName' => 'exchange-interop',
         ],
         'beanstalkQueue' => [
             'class' => \yii\queue\beanstalk\Queue::class,

--- a/tests/app/config/main.php
+++ b/tests/app/config/main.php
@@ -75,6 +75,8 @@ $config = [
         ],
         'amqpInteropQueue' => [
             'class' => \yii\queue\amqp_interop\Queue::class,
+            'queueName' => 'queue-interop',
+            'exchangeName' => 'exchange-interop',
         ],
         'beanstalkQueue' => [
             'class' => \yii\queue\beanstalk\Queue::class,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,7 @@ require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 Yii::setAlias('@yii/queue', dirname(__DIR__) . '/src');
 Yii::setAlias('@yii/queue/amqp', dirname(__DIR__) . '/src/drivers/amqp');
+Yii::setAlias('@yii/queue/amqp_interop', dirname(__DIR__) . '/src/drivers/amqp_interop');
 Yii::setAlias('@yii/queue/beanstalk', dirname(__DIR__) . '/src/drivers/beanstalk');
 Yii::setAlias('@yii/queue/db', dirname(__DIR__) . '/src/drivers/db');
 Yii::setAlias('@yii/queue/file', dirname(__DIR__) . '/src/drivers/file');

--- a/tests/drivers/amqp_interop/QueueTest.php
+++ b/tests/drivers/amqp_interop/QueueTest.php
@@ -42,21 +42,21 @@ class QueueTest extends CliTestCase
 
     public function testRun()
     {
-        // Not supported
+        $this->markTestSkipped('Not supported');
     }
 
     public function testStatus()
     {
-        // Not supported
+        $this->markTestSkipped('Not supported');
     }
 
     public function testLater()
     {
-        // Not supported
+        $this->markTestSkipped('Not supported');
     }
 
     public function testRetry()
     {
-        // Limited support
+        $this->markTestSkipped('Not supported');
     }
 }

--- a/tests/drivers/amqp_interop/QueueTest.php
+++ b/tests/drivers/amqp_interop/QueueTest.php
@@ -14,7 +14,7 @@ use yii\queue\amqp_interop\Queue;
 /**
  * AMQP Queue Test
  *
- * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ * @author Maksym Kotliar <kotlyar.maksim@gmail.com>
  */
 class QueueTest extends CliTestCase
 {

--- a/tests/drivers/amqp_interop/QueueTest.php
+++ b/tests/drivers/amqp_interop/QueueTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace tests\drivers\amqp_interop;
+
+use tests\drivers\CliTestCase;
+use Yii;
+use yii\queue\amqp_interop\Queue;
+
+/**
+ * AMQP Queue Test
+ *
+ * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ */
+class QueueTest extends CliTestCase
+{
+    protected function setUp()
+    {
+        if ('true' == getenv('EXCLUDE_AMQP_INTEROP')) {
+            $this->markTestSkipped('Amqp tests are disabled for php 5.5');
+        }
+
+        /** @var Queue $queue */
+        $queue = Yii::$app->amqpInteropQueue;
+        $queue->getContext()->deleteQueue($queue->getContext()->createQueue($queue->queueName));
+        $queue->getContext()->deleteTopic($queue->getContext()->createTopic($queue->exchangeName));
+
+        parent::setUp();
+    }
+
+    /**
+     * @return Queue
+     */
+    protected function getQueue()
+    {
+        return Yii::$app->amqpInteropQueue;
+    }
+
+    public function testRun()
+    {
+        // Not supported
+    }
+
+    public function testStatus()
+    {
+        // Not supported
+    }
+
+    public function testLater()
+    {
+        // Not supported
+    }
+
+    public function testRetry()
+    {
+        // Limited support
+    }
+}

--- a/tests/yii
+++ b/tests/yii
@@ -8,6 +8,7 @@ require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
 
 Yii::setAlias('@yii/queue', dirname(__DIR__) . '/src');
 Yii::setAlias('@yii/queue/amqp', dirname(__DIR__) . '/src/drivers/amqp');
+Yii::setAlias('@yii/queue/amqp_interop', dirname(__DIR__) . '/src/drivers/amqp_interop');
 Yii::setAlias('@yii/queue/beanstalk', dirname(__DIR__) . '/src/drivers/beanstalk');
 Yii::setAlias('@yii/queue/db', dirname(__DIR__) . '/src/drivers/db');
 Yii::setAlias('@yii/queue/file', dirname(__DIR__) . '/src/drivers/file');


### PR DESCRIPTION
Advantages:

* It would work with any amqp interop compatible transports, such as 

    * [enqueue/amqp-ext](https://github.com/php-enqueue/amqp-ext) based on [php amqp extension](https://github.com/pdezwart/php-amqp)
    * [enqueue/amqp-lib](https://github.com/php-enqueue/amqp-lib) based on [php-amqplib/php-amqplib](https://github.com/php-amqplib/php-amqplib)
    * [enqueue/amqp-bunny](https://github.com/php-enqueue/amqp-bunny) based on [bunny](https://github.com/jakubkulhan/bunny)
* Supports priorities
* Supports delays
* Supports ttr
* Supports attempts
* Contains new options like: vhost, connection_timeout, qos_prefetch_count and so on.
* Supports Secure (SSL) AMQP connections.
* Add ability to set DSN like: amqp:, amqps: or amqp://user:pass@localhost:1000/vhost