### PR TITLE
Improve grammar and language style

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
     <br>
 </p>
 
-An extension for running tasks asyncronously via queues.
+An extension for running tasks asynchronously via queues.
 
-It supported queues based on **DB**, **Redis**, **RabbitMQ**, **Beanstalk** and **Gearman**.
+It supports queues based on **DB**, **Redis**, **RabbitMQ**, **AMQP**, **Beanstalk** and **Gearman**.
 
 Documentation is at [docs/guide/README.md](docs/guide/README.md).
 
@@ -54,7 +54,7 @@ class DownloadJob extends BaseObject implements \yii\queue\JobInterface
 }
 ```
 
-Here's how to send a task into queue:
+Here's how to send a task into the queue:
 
 ```php
 Yii::$app->queue->push(new DownloadJob([
@@ -62,7 +62,7 @@ Yii::$app->queue->push(new DownloadJob([
     'file' => '/tmp/image.jpg',
 ]));
 ```
-Pushes job into queue that run after 5 min:
+To push a job into the queue that should run after 5 minutes:
 
 ```php
 Yii::$app->queue->delay(5 * 60)->push(new DownloadJob([
@@ -71,36 +71,36 @@ Yii::$app->queue->delay(5 * 60)->push(new DownloadJob([
 ]));
 ```
 
-The exact way task is executed depends on the driver used. The most part of drivers can be run using
-console commands, which the component registers in your application.
+The exact way a task is executed depends on the used driver. Most drivers can be run using
+console commands, which the component automatically registers in your application.
 
-Command that obtains and executes tasks in a loop until queue is empty:
+This command obtains and executes tasks in a loop until the queue is empty:
 
 ```sh
 yii queue/run
 ```
 
-Command launches a daemon which infinitely queries the queue:
+This command launches a daemon which infinitely queries the queue:
 
 ```sh
 yii queue/listen
 ```
 
-See documentation for more details about driver console commands and their options.
+See the documentation for more details about driver specific console commands and their options.
 
-The component has ability to track status of a job which was pushed into queue.
+The component also has the ability to track the status of a job which was pushed into queue.
 
 ```php
-// Push a job into queue and get message ID.
+// Push a job into the queue and get a message ID.
 $id = Yii::$app->queue->push(new SomeJob());
 
-// The job is waiting for execute.
+// Check whether the job is waiting for execution.
 Yii::$app->queue->isWaiting($id);
 
-// Worker gets the job from queue, and executing it.
+// Check whether a worker got the job from the queue and executes it.
 Yii::$app->queue->isReserved($id);
 
-// Worker has executed the job.
+// Check whether a worker has executed the job.
 Yii::$app->queue->isDone($id);
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,26 +7,26 @@ application when you upgrade the package from one version to another.
 Upgrade from 2.0.1 to 2.0.2
 ---------------------------
 
-* The [Amqp driver](docs/guide/driver-amqp.md) has been deprecated. You can still use till `2.1` release
-  where it will be removed. It is advised to migrate to [Amqp Interop](docs/guide/driver-amqp-interop.md).
+* The [Amqp driver](docs/guide/driver-amqp.md) has been deprecated and will be removed in `2.1`.
+  It is advised to migrate to [Amqp Interop](docs/guide/driver-amqp-interop.md) instead.
 
-* Added `\yii\queue\cli\Command::isWorkerAction()` abstract method. If you use yourself console
+* Added `\yii\queue\cli\Command::isWorkerAction()` abstract method. If you use your own console
   controllers to run queue listeners, you must implement it.
 
-* `\yii\queue\cli\Signal` helper is deprecated and will be removed since `2.1`.  The extension uses
+* `\yii\queue\cli\Signal` helper is deprecated and will be removed in `2.1`.  The extension uses
   `\yii\queue\cli\SignalLoop` instead of the helper.
 
-* If you had made yourself console controller to listen a queue, you must upgrade it. See native
-  console controllers to upgrade.
+* If you use your own console controller to listen to a queue, you must upgrade it. See the native
+  console controllers for how to upgrade.
 
 Upgrade from 2.0.0 to 2.0.1
 ---------------------------
 
-* `yii\queue\cli\Verbose` behavior was renamed to `yii\queue\cli\VerboseBehavior`. Old class was
+* `yii\queue\cli\Verbose` behavior was renamed to `yii\queue\cli\VerboseBehavior`. The old class was
   marked as deprecated and will be removed in `2.1.0`.
 
 * `Job`, `RetryableJob` and `Serializer` interfaces were renamed to `JobInterface`,
-  `RetryableJobInterface` and `SerializerInterface`. Old names are declared as deprecated
+  `RetryableJobInterface` and `SerializerInterface`. The old names are declared as deprecated
   and will be removed in `2.1.0`.
 
 Upgrade from 1.1.0 to 2.0.0
@@ -48,25 +48,25 @@ Upgrade from 1.0.0 to 1.1.0
 Upgrade from 0.x to 1.0.0
 -------------------------
 
-* Some methods and constants was modified.
-  
+* Some methods and constants were modified.
+
   - Method `Job::run()` modified to `Job::execute($queue)`.
   - Const `Queue::EVENT_BEFORE_WORK` renamed to `Queue::EVENT_BEFORE_EXEC`.
   - Const `Queue::EVENT_AFTER_WORK` renamed to `Queue::EVENT_AFTER_EXEC`.
   - Const `Queue::EVENT_AFTER_ERROR` renamed to `Queue::EVENT_AFTER_EXEC_ERROR`.
 
-* Method `Queue::sendMessage` renamed to `Queue::pushMessage`. Check it if you use it for yourself
-  drivers.
+* Method `Queue::sendMessage` renamed to `Queue::pushMessage`. Check it if you use it in your own
+  custom drivers.
 
 
 Upgrade from 0.10.1
 -------------------
 
 * Driver property was removed and this functionality was moved into queue classes. If you use public
-  methods of `Yii::$app->queue->driver` you need to use methods of `Yii::$app->queue`. 
-  
-  And you need to check your configs. For example, now config for db queue see:
-  
+  methods of `Yii::$app->queue->driver` you need to use the methods of `Yii::$app->queue`.
+
+  You also need to check your configs. For example, now the config for the db queue is:
+
   ```php
   'queue' => [
       'class' => \zhuravljov\yii\queue\db\Queue::class,
@@ -76,9 +76,9 @@ Upgrade from 0.10.1
       'mutex' => \yii\mutex\MysqlMutex::class,
   ],
   ```
- 
-  Instead of old variant:
- 
+
+  Instead of the old variant:
+
   ```php
   'queue' => [
       'class' => \zhuravljov\yii\queue\Queue::class,
@@ -91,4 +91,3 @@ Upgrade from 0.10.1
       ],
   ],
   ```
-  

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,19 +1,19 @@
 Yii2 Queue extension
 ====================
 
-An extension for running tasks asyncronously via queues.
+An extension for running tasks asynchronously via queues.
 
 Introduction
 ------------
 
 * [Usage basics](usage.md)
 * [Errors and retryable jobs](retryable.md)
-* [Worker starting control](worker.md)
+* [Starting workers](worker.md)
 
 Queue Drivers
 -------------
 
-* [Syncronous](driver-sync.md)
+* [Synchronous](driver-sync.md)
 * [File](driver-file.md)
 * [Db](driver-db.md)
 * [Redis](driver-redis.md)

--- a/docs/guide/debug.md
+++ b/docs/guide/debug.md
@@ -1,10 +1,10 @@
 Debugging
 =========
 
-In order for development process to be more friendly you may add a panel to Yii2 debug module. The panel displays a
-counter and a list of queued tasks.
+During development you may want to add a panel for the Yii2 debug module.
+The panel displays a counter and a list of queued tasks.
 
-`yiisoft/yii2-debug` should be installed in your application in order for the panel to be displayed.
+The `yiisoft/yii2-debug` module should be installed in your application for the panel to be displayed.
 
 Configure your application like the following:
 

--- a/docs/guide/driver-amqp-interop.md
+++ b/docs/guide/driver-amqp-interop.md
@@ -1,32 +1,33 @@
-AMQP Interop 
+AMQP Interop
 ============
 
-The driver works with RabbitMQ queues.
+This driver works with RabbitMQ queues.
 
-In order for it to work you should add any [amqp interop](https://github.com/queue-interop/queue-interop#amqp-interop) compatible transport to your project, for example `enqueue/amqp-lib` package.
+It requires an [amqp interop](https://github.com/queue-interop/queue-interop#amqp-interop) compatible
+transport, for example the `enqueue/amqp-lib` package.
 
 Advantages:
 
-* It would work with any amqp interop compatible transports, such as 
+* It works with any amqp interop compatible transports, such as 
 
     * [enqueue/amqp-ext](https://github.com/php-enqueue/amqp-ext) based on [PHP amqp extension](https://github.com/pdezwart/php-amqp)
     * [enqueue/amqp-lib](https://github.com/php-enqueue/amqp-lib) based on [php-amqplib/php-amqplib](https://github.com/php-amqplib/php-amqplib)
     * [enqueue/amqp-bunny](https://github.com/php-enqueue/amqp-bunny) based on [bunny](https://github.com/jakubkulhan/bunny)
-    
+
 * Supports priorities
 * Supports delays
 * Supports ttr
 * Supports attempts
 * Contains new options like: vhost, connection_timeout, qos_prefetch_count and so on.
 * Supports Secure (SSL) AMQP connections.
-* An ability to set DSN like: amqp:, amqps: or amqp://user:pass@localhost:1000/vhost
+* Has the ability to set DSN like: amqp:, amqps: or amqp://user:pass@localhost:1000/vhost
 
 Configuration example:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'queue' => [
@@ -36,10 +37,10 @@ return [
             'password' => 'guest',
             'queueName' => 'queue',
             'driver' => yii\queue\amqp_interop\Queue::ENQUEUE_AMQP_LIB,
-            
+
             // or
             'dsn' => 'amqp://guest:guest@localhost:5672/%2F',
-            
+
             // or, same as above
             'dsn' => 'amqp:',
         ],
@@ -50,18 +51,13 @@ return [
 Console
 -------
 
-Console is used to listen and process queued tasks.
+A console command is used to execute queued jobs.
 
 ```sh
-yii queue/listen
+yii queue/listen [timeout]
 ```
 
-`listen` command launches a daemon which infinitely queries the queue. If there are new tasks
-they're immediately obtained and executed. This method is most efficient when command is properly
-daemonized via [supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).
-
-`listen` command has options:
-
-- `--verbose`, `-v`: print executing statuses into console.
-- `--isolate`: verbose mode of a job execute. If enabled, execute result of each job will be printed.
-- `--color`: highlighting for verbose mode.
+The `listen` command launches a daemon which infinitely queries the queue. If there are new tasks
+they're immediately obtained and executed. The `timeout` parameter specifies the number of seconds to sleep between
+querying the queue. This method is most efficient when the command is properly daemonized via
+[supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).

--- a/docs/guide/driver-amqp.md
+++ b/docs/guide/driver-amqp.md
@@ -1,19 +1,19 @@
 RabbitMQ Driver
 ===============
 
-**Note:** The driver has been deprecated since 2.0.2 and will be removed in 2.1.
-Consider using [amqp_interop](driver-amqp-interop.md) driver instead.
+**Note:** This driver has been deprecated since 2.0.2 and will be removed in 2.1.
+Consider using the [amqp_interop](driver-amqp-interop.md) driver instead.
 
-The driver works with RabbitMQ queues.
+This driver works with RabbitMQ queues.
 
-In order for it to work you should add `php-amqplib/php-amqplib` package to your project.
+It requires the `php-amqplib/php-amqplib` package.
 
 Configuration example:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'queue' => [
@@ -31,18 +31,13 @@ return [
 Console
 -------
 
-Console is used to listen and process queued tasks.
+A console command is used to execute queued jobs.
 
 ```sh
-yii queue/listen
+yii queue/listen [timeout]
 ```
 
-`listen` command launches a daemon which infinitely queries the queue. If there are new tasks
-they're immediately obtained and executed. This method is most efficient when command is properly
-daemonized via [supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).
-
-`listen` command has options:
-
-- `--verbose`, `-v`: print executing statuses into console.
-- `--isolate`: verbose mode of a job execute. If enabled, execute result of each job will be printed.
-- `--color`: highlighting for verbose mode.
+The `listen` command launches a daemon which infinitely queries the queue. If there are new tasks
+they're immediately obtained and executed. The `timeout` parameter specifies the number of seconds to sleep between
+querying the queue. This method is most efficient when the command is properly daemonized via
+[supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).

--- a/docs/guide/driver-beanstalk.md
+++ b/docs/guide/driver-beanstalk.md
@@ -1,14 +1,14 @@
 Beanstalk Driver
 ================
 
-The driver works with Beanstalk queues.
+This driver works with Beanstalk queues.
 
 Configuration example:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'queue' => [
@@ -24,38 +24,38 @@ return [
 Console
 -------
 
-Console command is used to execute tasks.
+Console commands are used to execute and manage queued jobs.
 
 ```sh
 yii queue/listen [timeout]
 ```
 
-`listen` command launches a daemon which infinitely queries the queue. If there are new tasks
-they're immediately obtained and executed. `timeout` parameter is a number of seconds to wait a job.
-This method is most efficient when command is properly daemonized via
+The `listen` command launches a daemon which infinitely queries the queue. If there are new tasks
+they're immediately obtained and executed. The `timeout` parameter specifies the number of seconds to sleep between
+querying the queue. This method is most efficient when the command is properly daemonized via
 [supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).
 
 ```sh
 yii queue/run
 ```
 
-`run` command obtains and executes tasks in a loop until queue is empty. Works well with
+The `run` command obtains and executes tasks in a loop until the queue is empty. This works well with
 [cron](worker.md#cron).
 
-`run` and `listen` commands have options:
+The `run` and `listen` commands have options:
 
-- `--verbose`, `-v`: print executing statuses into console.
-- `--isolate`: verbose mode of a job execute. If enabled, execute result of each job will be printed.
-- `--color`: highlighting for verbose mode.
+- `--verbose`, `-v`: print execution statuses to console.
+- `--isolate`: verbose mode of a job execution. If enabled, the execution results of each job will be printed.
+- `--color`: enable highlighting for verbose mode.
 
 ```sh
 yii queue/info
 ```
 
-`info` command prints out information about queue status.
+The `info` command prints out information about the queue status.
 
 ```sh
 yii queue/remove [id]
 ```
 
-`remove` command removes a job.
+The `remove` command removes a job from the queue.

--- a/docs/guide/driver-db.md
+++ b/docs/guide/driver-db.md
@@ -1,14 +1,14 @@
 DB Driver
 =========
 
-DB driver uses database to store queue data.
+The DB driver uses a database to store queue data.
 
 Configuration example:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'db' => [
@@ -20,7 +20,7 @@ return [
             'db' => 'db', // DB connection component or its config 
             'tableName' => '{{%queue}}', // Table name
             'channel' => 'default', // Queue channel key
-            'mutex' => \yii\mutex\MysqlMutex::class, // Mutex that used to sync queries
+            'mutex' => \yii\mutex\MysqlMutex::class, // Mutex used to sync queries
         ],
     ],
 ];
@@ -49,8 +49,8 @@ CREATE TABLE `queue` (
 
 Migrations are available from [src/drivers/db/migrations](../../src/drivers/db/migrations).
 
-To add migrations to your application, edit console config file to configure
-[the namespaced migration](http://www.yiiframework.com/doc-2.0/guide-db-migrations.html#namespaced-migrations):
+To add migrations to your application, edit the console config file to configure
+[a namespaced migration](http://www.yiiframework.com/doc-2.0/guide-db-migrations.html#namespaced-migrations):
 
 ```php
 'controllerMap' => [
@@ -66,7 +66,7 @@ To add migrations to your application, edit console config file to configure
 ],
 ```
 
-Then issue migration command:
+Then issue the `migrate/up` command:
 
 ```sh
 yii migrate/up
@@ -75,44 +75,44 @@ yii migrate/up
 Console
 -------
 
-Console command is used to execute tasks.
+Console commands are used to execute and manage queued jobs.
 
 ```sh
 yii queue/listen [timeout]
 ```
 
-`listen` command launches a daemon which infinitely queries the queue. If there are new tasks
-they're immediately obtained and executed. `timeout` parameter is number of seconds to sleep between
-querying a queue next time. This method is most efficient when command is properly daemonized via
+The `listen` command launches a daemon which infinitely queries the queue. If there are new tasks
+they're immediately obtained and executed. The `timeout` parameter specifies the number of seconds to sleep between
+querying the queue. This method is most efficient when the command is properly daemonized via
 [supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).
 
 ```sh
 yii queue/run
 ```
 
-`run` command obtains and executes tasks in a loop until queue is empty. Works well with
+The `run` command obtains and executes tasks in a loop until the queue is empty. This works well with
 [cron](worker.md#cron).
 
-`run` and `listen` commands have options:
+The `run` and `listen` commands have options:
 
-- `--verbose`, `-v`: print executing statuses into console.
-- `--isolate`: verbose mode of a job execute. If enabled, execute result of each job will be printed.
-- `--color`: highlighting for verbose mode.
+- `--verbose`, `-v`: print execution statuses to console.
+- `--isolate`: verbose mode of a job execution. If enabled, the execution results of each job will be printed.
+- `--color`: enable highlighting for verbose mode.
 
 ```sh
 yii queue/info
 ```
 
-`info` command prints out information about queue status.
+The `info` command prints out information about the queue status.
 
 ```sh
 yii queue/clear
 ```
 
-`clear` command clears a queue.
+The `clear` command clears the queue.
 
 ```sh
 yii queue/remove [id]
 ```
 
-`remove` command removes a job.
+The `remove` command removes a job from the queue.

--- a/docs/guide/driver-file.md
+++ b/docs/guide/driver-file.md
@@ -1,14 +1,14 @@
 File Driver
 ===========
 
-File driver uses files to store queue data.
+The file driver uses files to store queue data.
 
 Configuration example:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'queue' => [
@@ -22,44 +22,44 @@ return [
 Console
 -------
 
-Console command is used to execute tasks.
+Console commands are used to execute and manage queued jobs.
 
 ```sh
-yii queue/listen [delay]
+yii queue/listen [timeout]
 ```
 
-`listen` command launches a daemon which infinitely queries the queue. If there are new tasks
-they're immediately obtained and executed. `timeout` parameter is number of seconds to sleep between
-querying a queue next time. This method is most efficient when command is properly daemonized via
+The `listen` command launches a daemon which infinitely queries the queue. If there are new tasks
+they're immediately obtained and executed. The `timeout` parameter specifies the number of seconds to sleep between
+querying the queue. This method is most efficient when the command is properly daemonized via
 [supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).
 
 ```sh
 yii queue/run
 ```
 
-`run` command obtains and executes tasks in a loop until queue is empty. Works well with
+The `run` command obtains and executes tasks in a loop until the queue is empty. This works well with
 [cron](worker.md#cron).
 
-`run` and `listen` commands have options:
+The `run` and `listen` commands have options:
 
-- `--verbose`, `-v`: print executing statuses into console.
-- `--isolate`: verbose mode of a job execute. If enabled, execute result of each job will be printed.
-- `--color`: highlighting for verbose mode.
+- `--verbose`, `-v`: print execution statuses to console.
+- `--isolate`: verbose mode of a job execution. If enabled, the execution results of each job will be printed.
+- `--color`: enable highlighting for verbose mode.
 
 ```sh
 yii queue/info
 ```
 
-`info` command prints out information about queue status.
+The `info` command prints out information about the queue status.
 
 ```sh
 yii queue/clear
 ```
 
-`clear` command clears a queue.
+The `clear` command clears the queue.
 
 ```sh
 yii queue/remove [id]
 ```
 
-`remove` command removes a job.
+The `remove` command removes a job from the queue.

--- a/docs/guide/driver-gearman.md
+++ b/docs/guide/driver-gearman.md
@@ -1,14 +1,14 @@
 Gearman Driver
 ==============
 
-Driver works with Gearman queues.
+This driver works with Gearman queues.
 
 Configuration example:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'queue' => [
@@ -24,7 +24,7 @@ return [
 Console
 -------
 
-Console is used to process queued tasks.
+Console commands are used to process queued tasks.
 
 ```sh
 yii queue/listen

--- a/docs/guide/driver-redis.md
+++ b/docs/guide/driver-redis.md
@@ -1,22 +1,22 @@
 Redis Driver
 ============
 
-The driver uses Redis to store queue data.
+This driver uses Redis to store queue data.
 
-You have to add `yiisoft/yii2-redis` extension to your application in order to use it.
+You have to add the `yiisoft/yii2-redis` extension to your application in order to use it.
 
 Configuration example:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'redis' => [
             'class' => \yii\redis\Connection::class,
             // ...
-            
+
             // retry connecting after connection has timed out
             // yiisoft/yii2-redis >=2.0.7 is required for this.
             'retries' => 1,
@@ -33,44 +33,44 @@ return [
 Console
 -------
 
-Console command is used to execute tasks.
+Console commands are used to execute and manage queued jobs.
 
 ```sh
 yii queue/listen [timeout]
 ```
 
-`listen` command launches a daemon which infinitely queries the queue. If there are new tasks
-they're immediately obtained and executed. `timeout` parameter is number of seconds to wait a job.
-This method is most efficient when command is properly daemonized via
+The `listen` command launches a daemon which infinitely queries the queue. If there are new tasks
+they're immediately obtained and executed. The `timeout` parameter specifies the number of seconds to sleep between
+querying the queue. This method is most efficient when the command is properly daemonized via
 [supervisor](worker.md#supervisor) or [systemd](worker.md#systemd).
 
 ```sh
 yii queue/run
 ```
 
-`run` command obtains and executes tasks in a loop until queue is empty. Works well with
+The `run` command obtains and executes tasks in a loop until the queue is empty. This works well with
 [cron](worker.md#cron).
 
-`run` and `listen` commands have options:
+The `run` and `listen` commands have options:
 
-- `--verbose`, `-v`: print executing statuses into console.
-- `--isolate`: verbose mode of a job execute. If enabled, execute result of each job will be printed.
-- `--color`: highlighting for verbose mode.
+- `--verbose`, `-v`: print execution statuses to console.
+- `--isolate`: verbose mode of a job execution. If enabled, the execution results of each job will be printed.
+- `--color`: enable highlighting for verbose mode.
 
 ```sh
 yii queue/info
 ```
 
-`info` command prints out information about queue status.
+The `info` command prints out information about the queue status.
 
 ```sh
 yii queue/clear
 ```
 
-`clear` command clears a queue.
+The `clear` command clears the queue.
 
 ```sh
 yii queue/remove [id]
 ```
 
-`remove` command removes a job.
+The `remove` command removes a job from the queue.

--- a/docs/guide/driver-sync.md
+++ b/docs/guide/driver-sync.md
@@ -1,8 +1,8 @@
-Syncronous Driver
-=================
+Synchronous Driver
+==================
 
-Runs tasks syncronously in the same process if `handle` property is turned on. Could be used when developing and debugging
-application.
+Runs tasks synchronously in the same process if the `handle` property is turned on.
+It could be used when developing and debugging an application.
 
 Configuration example:
 
@@ -11,7 +11,7 @@ return [
     'components' => [
         'queue' => [
             'class' => \yii\queue\sync\Queue::class,
-            'handle' => false, // if tasks should be executed immediately
+            'handle' => false, // whether tasks should be executed immediately
         ],
     ],
 ];

--- a/docs/guide/gii.md
+++ b/docs/guide/gii.md
@@ -1,13 +1,12 @@
-Code generator Gii
+Gii Code generator
 ==================
 
-In order to create a job template you can use the Gii code generator.
+You can use the Gii code generator to create a job template.
 
 Configuration
 -------------
 
-In order to use Gii job generator you have to configure it like the following:  
-(for example into `backend/config/main-local.php`)
+To use the Gii job generator you have to configure it like the following:
 
 ```php
 if (!YII_ENV_TEST) {
@@ -24,6 +23,6 @@ if (!YII_ENV_TEST) {
 
 ```
 
-After doing it you'll find the generator in the menu.
+After doing so you'll find the generator in the Gii menu.
 
 ![default](https://user-images.githubusercontent.com/1656851/29426628-e9a3e5ae-838f-11e7-859f-6f3cb8649f02.png)

--- a/docs/guide/retryable.md
+++ b/docs/guide/retryable.md
@@ -1,38 +1,41 @@
 Errors and retryable jobs
 =========================
 
-Exceptions can be thrown during job handling. This can be internal errors which result of poorly
-written code, and external, when the requested services and external resources are unavailable.
-In the second case, it's good to be able to retry a job after time.
+The execution of a job can fail. This can be due to internal errors which result from
+poorly written code which should be fixed first. But they can also fail due to external
+problems like a service or a resource being unavailable. This can lead to Exceptions or
+timeouts.
 
-There are several ways to do this.
+In the latter cases, it's good to be able to retry a job after some time. There are several ways to do this.
 
 Retry options
 -------------
 
-The first method is implemented by the component options:
+The first method is to use component options:
 
 ```php
 'components' => [
     'queue' => [
         'class' => \yii\queue\<driver>\Queue::class,
-        'ttr' => 5 * 60, // Max time for anything job handling 
+        'ttr' => 5 * 60, // Max time for job execution
         'attempts' => 3, // Max number of attempts
     ],
 ],
 ```
 
-The `ttr` option sets time to reserve of a job in queue. If a job doesn't executed during this time,
-it will return to a queue for retry. The `attempts` option sets max number of attempts. If attempts
-are over, and the job isn't done, it will be removed from a queue as completed.
+The `ttr` option sets the time to reserve for job execution. If the execution of a job takes longer than
+this time, execution will be stopped and it will be returned to the queue for later retry. The same happens
+if the job throws an Exception. The `attempts` option sets the max. number of attempts. If this number is
+reached, and the job still isn't done, it will be removed from the queue as completed.
 
-The options extend to all jobs in a queue, and if you need to change this behavior fo several jobs,
-there is second method.
- 
+These options apply to all jobs in the queue. If you need to change this behavior for specific
+jobs, see the following method.
+
 RetryableJobInterface
 ---------------------
 
-Separate control of retry is implemented by `RetryableJobInterface` interface. For example:
+To have more control over the retry logic a job can implement the `RetryableJobInterface`.
+For example:
 
 ```php
 class SomeJob extends BaseObject implements RetryableJobInterface
@@ -54,15 +57,15 @@ class SomeJob extends BaseObject implements RetryableJobInterface
 }
 ```
 
-`getTtr()` and `canRetry()` methods have a higher priority than the component options.
+The `getTtr()` and `canRetry()` methods have a higher priority than the component options mentioned above.
 
 Event handlers
 --------------
 
-The third method to set TTR and the need to retry of failed job involves using
+The third method to control TTR and number of retries for failed jobs involves the
 `Queue::EVENT_BEFORE_PUSH` and `Queue::EVENT_AFTER_ERROR` events.
 
-`Queue::EVENT_BEFORE_PUSH` event can be used to set TTR:
+The TTR can be set with the `Queue::EVENT_BEFORE_PUSH` event:
 
 ```php
 Yii::$app->queue->on(Queue::EVENT_BEFORE_PUSH, function (PushEvent $event) {
@@ -72,7 +75,7 @@ Yii::$app->queue->on(Queue::EVENT_BEFORE_PUSH, function (PushEvent $event) {
 });
 ```
 
-And `Queue::EVENT_AFTER_ERROR` event can be used to set a new attempt:
+And the `Queue::EVENT_AFTER_ERROR` event can be used to decide whether to try another attempt:
 
 ```php
 Yii::$app->queue->on(Queue::EVENT_AFTER_ERROR, function (ErrorEvent $event) {
@@ -88,9 +91,9 @@ priority.
 Restrictions
 ------------
 
-Full support of retryable implements for [Beanstalk], [DB], [File], [AMQP Interop] and [Redis] drivers.
-[Sync] driver will not retry failed jobs. [Gearman] driver doesn't support of retryable.
-[RabbitMQ] has only its basic retryable support, in which an attempt number can not be got.
+Full support for retryable jobs is implemented in the [Beanstalk], [DB], [File], [AMQP Interop] and [Redis] drivers.
+The [Sync] driver will not retry failed jobs. The [Gearman] driver doesn't support retryable jobs.
+[RabbitMQ] has only its basic retryable support, where the number of attempts can not be set.
 
 [Beanstalk]: driver-beanstalk.md
 [DB]: driver-db.md

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -5,12 +5,12 @@ Usage basics
 Configuration
 -------------
 
-In order to use extension you have to configure it like the following:
+In order to use the extension you have to configure it like the following:
 
 ```php
 return [
     'bootstrap' => [
-        'queue', // The component registers own console commands
+        'queue', // The component registers its own console commands
     ],
     'components' => [
         'queue' => [
@@ -22,13 +22,13 @@ return [
 ];
 ```
 
-A list of drivers available and their configuration docs is available in [table of contents](README.md).
+A list of available drivers and their docs is available in the [table of contents](README.md).
 
 
-Usage in code
--------------
+Usage
+-----
 
-Each task which is sent to queue should be defined as a separate class.
+Each task which is sent to the queue should be defined as a separate class.
 For example, if you need to download and save a file the class may look like the following:
 
 ```php
@@ -44,7 +44,7 @@ class DownloadJob extends BaseObject implements \yii\queue\JobInterface
 }
 ```
 
-Here's how to send a task into queue:
+Here's how to send a task to the queue:
 
 ```php
 Yii::$app->queue->push(new DownloadJob([
@@ -52,7 +52,7 @@ Yii::$app->queue->push(new DownloadJob([
     'file' => '/tmp/image.jpg',
 ]));
 ```
-Pushes job into queue that run after 5 min:
+To push a job into the queue that should run after 5 minutes:
 
 ```php
 Yii::$app->queue->delay(5 * 60)->push(new DownloadJob([
@@ -61,43 +61,43 @@ Yii::$app->queue->delay(5 * 60)->push(new DownloadJob([
 ]));
 ```
 
-**Important:** only some drivers support delayed running.
+**Important:** Not all drivers support delayed running.
 
 
 Queue handling
 --------------
 
-The exact way task is executed depends on the driver used. The most part of drivers can be run using
-console commands, which the component registers in your application. For more details see documentation
-of a driver.
+The exact way how a task is executed depends on the driver being used. Most drivers can be run using
+console commands, which the component registers in your application. For more details check the respective
+driver documentation.
 
 
 Job status
 ----------
 
-The component has ability to track status of a job which was pushed into queue.
+The component can track the status of a job that was pushed into the queue.
 
 ```php
-// Push a job into queue and get massage ID.
+// Push a job into the queue and get a message ID.
 $id = Yii::$app->queue->push(new SomeJob());
 
-// The job is waiting for execute.
+// Check whether the job is waiting for execution.
 Yii::$app->queue->isWaiting($id);
 
-// Worker gets the job from queue, and executing it.
+// Check whether a worker got the job from the queue and executes it.
 Yii::$app->queue->isReserved($id);
 
-// Worker has executed the job.
+// Check whether a worker has executed the job.
 Yii::$app->queue->isDone($id);
 ```
 
-**Important:** RabbitMQ driver doesn't support job statuses.
+**Important:** The RabbitMQ driver doesn't support job statuses.
 
 
 Messaging third party workers
 -----------------------------
 
-You may pass any data to queue:
+You may pass any data to the queue:
 
 ```php
 Yii::$app->queue->push([
@@ -107,10 +107,10 @@ Yii::$app->queue->push([
 ]);
 ```
 
-This is useful if the queue is processed using a specially developer third party worker.
+This is useful if the queue is processed using a custom third party worker.
 
-If worker is implemented using something other than PHP you have to change the way data is serialized. For example,
-to JSON:
+If the worker is not implemented in PHP you have to change the way data is serialized.
+For example to serialize to JSON:
 
 ```php
 return [
@@ -127,27 +127,27 @@ return [
 Handling events
 ---------------
 
-Queue triggers the following events:
+The queue triggers the following events:
 
-| Event name                   | Event class | Triggered on                                              |
+| Event name                   | Event class | Triggered                                                 |
 |------------------------------|-------------|-----------------------------------------------------------|
-| Queue::EVENT_BEFORE_PUSH     | PushEvent   | Adding job to queue using `Queue::push()` method          |
-| Queue::EVENT_AFTER_PUSH      | PushEvent   | Adding job to queue using `Queue::push()` method          |
-| Queue::EVENT_BEFORE_EXEC     | ExecEvent   | Before each job execution                                 |
-| Queue::EVENT_AFTER_EXEC      | ExecEvent   | After each success job execution                          |
-| Queue::EVENT_AFTER_ERROR     | ErrorEvent  | When uncaught exception occurred during the job execution |
-| cli\Queue:EVENT_WORKER_START | WorkerEvent | When worker has been started                              |
-| cli\Queue:EVENT_WORKER_LOOP  | WorkerEvent | Each iteration between requests to queue                  |
-| cli\Queue:EVENT_WORKER_STOP  | WorkerEvent | When worker has been stopped                              |
+| Queue::EVENT_BEFORE_PUSH     | PushEvent   | before adding a job to queue using `Queue::push()` method |
+| Queue::EVENT_AFTER_PUSH      | PushEvent   | after adding a job to queue using `Queue::push()` method  |
+| Queue::EVENT_BEFORE_EXEC     | ExecEvent   | before executing a job                                    |
+| Queue::EVENT_AFTER_EXEC      | ExecEvent   | after successful job execution                            |
+| Queue::EVENT_AFTER_ERROR     | ErrorEvent  | on uncaught exception during the job execution            |
+| cli\Queue:EVENT_WORKER_START | WorkerEvent | when worker has been started                              |
+| cli\Queue:EVENT_WORKER_LOOP  | WorkerEvent | on each iteration between requests to queue               |
+| cli\Queue:EVENT_WORKER_STOP  | WorkerEvent | when worker has been stopped                              |
 
 You can easily attach your own handler to any of these events.
-For example, let's delay the job, if its execution failed with a special exception: 
+For example, let's delay the job, if its execution failed with a special exception:
 
 ```php
 Yii::$app->queue->on(Queue::EVENT_AFTER_ERROR, function ($event) {
     if ($event->error instanceof TemporaryUnprocessableJobException) {
         $queue = $event->sender;
-        $queue->delay(7200)->push($event->job);    
+        $queue->delay(7200)->push($event->job);
     }
 });
 ```
@@ -155,10 +155,10 @@ Yii::$app->queue->on(Queue::EVENT_AFTER_ERROR, function ($event) {
 Logging events
 --------------
 
-This component provides the `LogBehavior` to log Queue events using
-[Yii built-in Logger](http://www.yiiframework.com/doc-2.0/guide-runtime-logging.html).
+The component provides the `LogBehavior` to log Queue events using
+[Yii's built-in Logger](http://www.yiiframework.com/doc-2.0/guide-runtime-logging.html).
 
-To use it, simply configure the Queue component as follows:
+To enable it, simply configure the queue component as follows:
 
 ```php
 return [
@@ -180,8 +180,8 @@ Configuration example:
 ```php
 return [
     'bootstrap' => [
-        'queue1', // First component registers own console commands
-        'queue2', // Second component registers own console commands
+        'queue1', // First component registers its own console commands
+        'queue2', // Second component registers its own console commands
     ],
     'components' => [
         'queue1' => [
@@ -199,13 +199,13 @@ return [
 Usage example:
 
 ```php
-// Sending task to queue to be processed via standard worker
+// Sending a task to the queue to be processed via standard worker
 Yii::$app->queue1->push(new DownloadJob([
     'url' => 'http://example.com/image.jpg',
     'file' => '/tmp/image.jpg',
 ]));
 
-// Sending tasks to another queue to be processed by third party worker
+// Sending a task to another queue to be processed by a third party worker
 Yii::$app->queue2->push([
     'function' => 'download',
     'url' => 'http://example.com/image.jpg',
@@ -217,13 +217,13 @@ Yii::$app->queue2->push([
 Limitations
 -----------
 
-When using queues it's important to remember that tasks are put into queue and are obtained from queue in separate
+When using queues it's important to remember that tasks are put into and obtained from the queue in separate
 processes. Therefore avoid external dependencies when executing a task if you're not sure if they are available in
-the environment where it worker does its job.
+the environment where the worker does its job.
 
-All the data to process the task should be put into properties of your job object and sent into queue along with it.
+All the data to process the task should be put into properties of your job object and be sent into the queue along with it.
 
-If you need to process `ActiveRecord` then send its ID instead of the object itself. When processing you have to extract
+If you need to process an `ActiveRecord` then send its ID instead of the object itself. When processing you have to extract
 it from DB.
 
 For example:
@@ -244,7 +244,7 @@ class SomeJob extends BaseObject implements \yii\queue\JobInterface
     public $userId;
     public $bookId;
     public $someUrl;
-    
+
     public function execute($queue)
     {
         $user = User::findOne($this->userId);

--- a/docs/guide/worker.md
+++ b/docs/guide/worker.md
@@ -1,20 +1,20 @@
-Worker starting control
-=======================
+Starting Workers
+================
 
 Supervisor
 ----------
 
-Supervisor is process monitor for Linux. It automatically starts your console processes. For install
-on Ubuntu you need run command:
+[Supervisor](http://supervisord.org) is a process monitor for Linux. It automatically starts
+console processes.  On Ubuntu it can be installed with this command:
 
 ```sh
 sudo apt-get install supervisor
 ```
 
-Supervisor config files usually available in `/etc/supervisor/conf.d`. You can create any number of
-config files.
+Supervisor config files are usually available in `/etc/supervisor/conf.d`. You can create any number of
+config files there.
 
-Config example:
+Here's an example:
 
 ```conf
 [program:yii-queue-worker]
@@ -28,13 +28,13 @@ redirect_stderr=true
 stdout_logfile=/var/www/my_project/log/yii-queue-worker.log
 ```
 
-In this case Supervisor must starts 4 `queue/listen` workers. Worker output will write into log
-file.
+In this case Supervisor should start 4 `queue/listen` workers. The worker output will be written
+to the specified log file.
 
-For more info about Supervisor's configure and usage see [documentation](http://supervisord.org).
+For more info about Supervisor's configuration and usage see its [documentation](http://supervisord.org).
 
-Worker starting in daemon mode with `queue/listen` command supports [File], [Db], [Redis],
-[RabbitMQ], [AMQP Interop], [Beanstalk], [Gearman] drivers. For additional options see driver guide.
+Note that worker daemons started with `queue/listen` are only supported by the [File], [Db], [Redis],
+[RabbitMQ], [AMQP Interop], [Beanstalk] and [Gearman] drivers. For additional options see driver guide.
 
 [File]: driver-file.md
 [Db]: driver-db.md
@@ -47,9 +47,9 @@ Worker starting in daemon mode with `queue/listen` command supports [File], [Db]
 Systemd
 -------
 
-Systemd is an init system used in Linux to bootstrap the user space. To configure workers startup
+Systemd is another init system used on Linux to bootstrap the user space. To configure workers startup
 using systemd, create a config file named `yii-queue@.service` in `/etc/systemd/system` with
-the following contents:
+the following content:
 
 ```conf
 [Unit]
@@ -70,7 +70,7 @@ Restart=on-failure
 WantedBy=multi-user.target
 ```
 
-You need to reload systemd in order for it to re-read configuration:
+You need to reload systemd in order to re-read its configuration:
 
 ```sh
 systemctl daemon-reload
@@ -82,10 +82,10 @@ Set of commands to control workers:
 # To start two workers
 systemctl start yii-queue@1 yii-queue@2
 
-# To get status of running workers
+# To get the status of running workers
 systemctl status "yii-queue@*"
 
-# To stop the worker
+# To stop a specific worker
 systemctl stop yii-queue@2
 
 # To stop all running workers
@@ -100,18 +100,17 @@ To learn all features of systemd, check its [documentation](https://freedesktop.
 Cron
 ----
 
-You can start worker using cron. You have to use `queue/run` command. It works as long as queue
-contains jobs.
+You can also start workers using cron. Here you have to use the `queue/run` command.
 
-Config example: 
+Config example:
 
 ```sh
 * * * * * /usr/bin/php /var/www/my_project/yii queue/run
 ```
 
-In this case cron will start the command every minute. 
+In this case cron will run the command every minute.
 
-`queue/run` command is supported by [File], [Db], [Redis], [Beanstalk], [Gearman] drivers.
+The `queue/run` command is supported by the [File], [Db], [Redis], [Beanstalk], [Gearman] drivers.
 For additional options see driver guide.
 
 [File]: driver-file.md


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes (hope so)
| Fixed issues  | -

I tried to improve the grammar and language style of the docs to make it more readable.

I also had problems to understand the `ttr`/`attempts` feature from the existing docs. So I tried to rephrase this a little. In the existing docs it sounds as if a job must throw an Exception in order to get requeued. But as I understand it, there are two cases, that can lead to re-queue:

 * Job times out, if execution does not complete within `ttr`
 * Job throws an exception

It also wasn't clear, that a timed out job is killed automatically.

If any of this requires further refinement, I'm happy to change this.