### PR TITLE
Reduce roundtrip for remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ Yii2 Queue Extension Change Log
 2.1.1 under development
 -----------------------
 
-- no changes in this release.
-
+- Enh #248: Reduce roundtrips to beanstalk server when removing job (SamMousa)
 
 2.1.0 May 24, 2018
 ------------------

--- a/src/drivers/beanstalk/Queue.php
+++ b/src/drivers/beanstalk/Queue.php
@@ -8,6 +8,7 @@
 namespace yii\queue\beanstalk;
 
 use Pheanstalk\Exception\ServerException;
+use Pheanstalk\Job;
 use Pheanstalk\Pheanstalk;
 use Pheanstalk\PheanstalkInterface;
 use yii\base\InvalidArgumentException;

--- a/src/drivers/beanstalk/Queue.php
+++ b/src/drivers/beanstalk/Queue.php
@@ -103,8 +103,7 @@ class Queue extends CliQueue
     public function remove($id)
     {
         try {
-            $job = $this->getPheanstalk()->peek($id);
-            $this->getPheanstalk()->delete($job);
+            $this->getPheanstalk()->delete(new Job($id, null));
             return true;
         } catch (ServerException $e) {
             if (strpos($e->getMessage(), 'NOT_FOUND') === 0) {


### PR DESCRIPTION
Beanstalk only needs an ID to remove a job. 
There is no need to first retrieve the job (and its data) and then attempting to delete it.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

