### PR TITLE
add default job interface

### DIFF
--- a/src/DefaultJobInterface.php
+++ b/src/DefaultJobInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\queue;
+
+/**
+ * Job Interface.
+ *
+ * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ */
+interface DefaultJobInterface extends JobInterface
+{
+
+    /**
+     * @param Array $json json object
+     * @return void
+     */
+    public function setJson($json);
+
+}

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -77,6 +77,12 @@ abstract class Queue extends Component
      */
     public $attempts = 1;
 
+    /**
+     * @var string
+     * Default worker class
+     */
+    public $defaultWorker;
+
     private $pushTtr;
     private $pushDelay;
     private $pushPriority;
@@ -138,9 +144,9 @@ abstract class Queue extends Component
         $event = new PushEvent([
             'job' => $job,
             'ttr' => $this->pushTtr ?: (
-                $job instanceof RetryableJobInterface
-                    ? $job->getTtr()
-                    : $this->ttr
+            $job instanceof RetryableJobInterface
+                ? $job->getTtr()
+                : $this->ttr
             ),
             'delay' => $this->pushDelay ?: 0,
             'priority' => $this->pushPriority,
@@ -238,6 +244,16 @@ abstract class Queue extends Component
 
         if ($job instanceof JobInterface) {
             return [$job, null];
+        }
+
+        if ($this->defaultWorker){
+
+            $defaultJob = new  $this->defaultWorker;
+            if ($defaultJob instanceof DefaultJobInterface) {
+
+                $defaultJob->setJson($job);
+                return [$defaultJob, null];
+            }
         }
 
         return [null, new InvalidJobException($serialized, sprintf(

--- a/src/drivers/gearman/Queue.php
+++ b/src/drivers/gearman/Queue.php
@@ -101,5 +101,17 @@ class Queue extends CliQueue
         return $this->_client;
     }
 
+    /**
+     * @param $chanel
+     * @return $this
+     */
+    public function setChanel($channel){
+
+        $this->channel=$channel;
+
+        return $this;
+
+    }
+
     private $_client;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

Adding default worker. Use when you receive jobs from systems not implemented in PHP