### PR TITLE
add AWS SQS FIFO queue support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii2 Queue Extension Change Log
 - Bug #267: Fixed symfony/process incompatibility (rob006)
 - Enh: Job execution result that forwarded to the event handler (zhuravljov)
 - Enh: ErrorEvent mark as deprecated (zhuravljov)
+- Enh: Add AWS SQS FIFO support (kringkaste)
 
 2.1.0 May 24, 2018
 ------------------

--- a/docs/guide/driver-sqs.md
+++ b/docs/guide/driver-sqs.md
@@ -5,7 +5,7 @@ The driver uses AWS SQS to store queue data.
 
 You have to add `aws/aws-sdk-php` extension to your application in order to use it.
 
-Configuration example:
+Configuration example for standard queues:
 
 ```php
 return [
@@ -23,6 +23,30 @@ return [
     ],
 ];
 ```
+
+Configuration example for FIFO queues:
+
+```php
+return [
+    'bootstrap' => [
+        'queue', // The component registers own console commands
+    ],
+    'components' => [
+        'queue' => [
+            'class' => \yii\queue\sqs\Queue::class,
+            'url' => '<sqs url>',
+            'key' => '<key>',
+            'secret' => '<secret>',
+            'region' => '<region>',
+            'messageGroupId' => '<Group ID>',
+        ],
+    ],
+];
+```
+
+The message group ID is required by SQS for FIFO queues. You can configure your own or use the "default" value.
+
+The deduplication ID is generated automatically, so no matter if you have activated content based deduplication in the SQS queue or not, this ID will be used.
 
 Console
 -------

--- a/docs/guide/driver-sqs.md
+++ b/docs/guide/driver-sqs.md
@@ -46,7 +46,7 @@ return [
 
 The message group ID is required by SQS for FIFO queues. You can configure your own or use the "default" value.
 
-The deduplication ID is generated automatically, so no matter if you have activated content based deduplication in the SQS queue or not, this ID will be used.
+The deduplication ID is generated automatically, so no matter if you have activated content-based deduplication in the SQS queue or not, this ID will be used.
 
 Console
 -------

--- a/src/drivers/sqs/Queue.php
+++ b/src/drivers/sqs/Queue.php
@@ -189,12 +189,12 @@ class Queue extends CliQueue
             ],
         ];
 
-        if (substr($this->url,-5) === '.fifo') {
+        if (substr($this->url, -5) === '.fifo') {
             $request['MessageGroupId'] = $this->messageGroupId;
             $request['MessageDeduplicationId'] = hash('sha256', $message);
         }
 
-        $response = $this->getClient()->sendMessage();
+        $response = $this->getClient()->sendMessage($request);
         return $response['MessageId'];
     }
 

--- a/src/drivers/sqs/Queue.php
+++ b/src/drivers/sqs/Queue.php
@@ -47,6 +47,11 @@ class Queue extends CliQueue
      */
     public $version = 'latest';
     /**
+     * Message Group ID for FIFO queues.
+     * @var string
+     */
+    public $messageGroupId = 'default';
+    /**
      * @var string command class name
      * @inheritdoc
      */
@@ -172,7 +177,7 @@ class Queue extends CliQueue
             throw new NotSupportedException('Priority is not supported in this driver');
         }
 
-        $response = $this->getClient()->sendMessage([
+        $request = [
             'QueueUrl' => $this->url,
             'MessageBody' => $message,
             'DelaySeconds' => $delay,
@@ -182,7 +187,14 @@ class Queue extends CliQueue
                     'StringValue' => $ttr,
                 ],
             ],
-        ]);
+        ];
+
+        if (substr($this->url,-5) === '.fifo') {
+            $request['MessageGroupId'] = $this->messageGroupId;
+            $request['MessageDeduplicationId'] = hash('sha256', $message);
+        }
+
+        $response = $this->getClient()->sendMessage();
         return $response['MessageId'];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | not checked
| Fixed issues  | -

With this pull request we added support for AWS SQS FIFO queues. The FIFO queues have their own suffix ".fifo" in the URL and we use this to identify a FIFO queue. The required parameters for a FIFO queue have default values, so you can run a FIFO queue like a standard queue without changes. Optionally you can change the message group ID in the app.php.