### PR TITLE
Redis: Move expired jobs to the end of waiting list

### DIFF
--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -165,7 +165,7 @@ class Queue extends CliQueue
         if ($expired = $this->redis->zrevrangebyscore($from, $now, '-inf')) {
             $this->redis->zremrangebyscore($from, '-inf', $now);
             foreach ($expired as $id) {
-                $this->redis->rpush("$this->channel.waiting", $id);
+                $this->redis->lpush("$this->channel.waiting", $id);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Jobs without delay are being pushed into the end of queue (LPUSH), but when a job has some delay, it will be pushed on to the top of queue (RPUSH). As a result, expired job will be processed immediately, even when waiting list has a lot of pending jobs.

So, if you have a lot of delayed jobs, non-delayed ones are basically deprioritized.