### PR TITLE
Closes #293. Add method that provides public access for `handleMessage`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii2 Queue Extension Change Log
 - Bug #180: Fixed info command of file driver (victorruan)
 - Bug #92: Resolve issue in debug panel (farmani-eigital)
 - Enh: Start and stop events of a worker (zhuravljov)
+- Enh #293: Add `handle` method that provides public access for `handleMessage` which can be useful for handling jobs by webhooks (alexkart)
 
 ## 2.0.1, November 13, 2017
 

--- a/src/cli/Queue.php
+++ b/src/cli/Queue.php
@@ -118,11 +118,12 @@ abstract class Queue extends BaseQueue implements BootstrapInterface
     /**
      * Provides public access for `handleMessage`
      *
-     * @param $id
-     * @param $message
-     * @param $ttr
-     * @param $attempt
-     * @return bool|mixed
+     * @param $id string
+     * @param $message string
+     * @param $ttr int
+     * @param $attempt int
+     * @return bool
+     * @since 2.0.2
      */
     public function handle($id, $message, $ttr, $attempt)
     {

--- a/src/cli/Queue.php
+++ b/src/cli/Queue.php
@@ -116,6 +116,20 @@ abstract class Queue extends BaseQueue implements BootstrapInterface
     }
 
     /**
+     * Provides public access for `handleMessage`
+     *
+     * @param $id
+     * @param $message
+     * @param $ttr
+     * @param $attempt
+     * @return bool|mixed
+     */
+    public function handle($id, $message, $ttr, $attempt)
+    {
+        return $this->handleMessage($id, $message, $ttr, $attempt);
+    }
+
+    /**
      * @param string $id of a message
      * @param string $message
      * @param int $ttr time to reserve


### PR DESCRIPTION
Add method that provides public access for `handleMessage` as was agreed in the issue comments.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #293
