### PR TITLE
Support for redis job to be pushed from inside a redis multi block

### DIFF
--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -191,7 +191,7 @@ class Queue extends CliQueue
             throw new NotSupportedException('Job priority is not supported in the driver.');
         }
 
-        $id = $this->redis->incr("$this->channel.message_id");
+        $id = uniqid('', true);
         $this->redis->hset("$this->channel.messages", $id, "$ttr;$message");
         if (!$delay) {
             $this->redis->lpush("$this->channel.waiting", $id);

--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -73,10 +73,6 @@ class Queue extends CliQueue
      */
     public function status($id)
     {
-        if (!is_numeric($id) || $id <= 0) {
-            throw new InvalidArgumentException("Unknown message ID: $id.");
-        }
-
         if ($this->redis->hexists("$this->channel.attempts", $id)) {
             return self::STATUS_RESERVED;
         }


### PR DESCRIPTION
change the job id to be something that are not stored in redis, so that we can still push a job from inside a multi block

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #355 
