### PR TITLE
AMQP keepalive support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.6
   - 7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.1 under development
 -----------------------
 
-- no changes in this release.
+- Enh #372: Add ability to configure keepalive and heartbeat for Amqp (vyachin)
 
 
 2.3.0 June 04, 2019

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "yiisoft/yii2-redis": "*",
         "php-amqplib/php-amqplib": "*",
-        "enqueue/amqp-lib": "^0.8",
+        "enqueue/amqp-lib": "*",
         "pda/pheanstalk": "v3.*",
         "jeremeamia/superclosure": "*",
         "yiisoft/yii2-debug": "*",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "yiisoft/yii2-redis": "*",
         "php-amqplib/php-amqplib": "*",
-        "enqueue/amqp-lib": "^0.8||^0.9.10",
+        "enqueue/amqp-lib": "*",
         "pda/pheanstalk": "v3.*",
         "jeremeamia/superclosure": "*",
         "yiisoft/yii2-debug": "*",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "yiisoft/yii2-redis": "*",
         "php-amqplib/php-amqplib": "*",
-        "enqueue/amqp-lib": "*",
+        "enqueue/amqp-lib": "^0.8",
         "pda/pheanstalk": "v3.*",
         "jeremeamia/superclosure": "*",
         "yiisoft/yii2-debug": "*",

--- a/src/drivers/amqp/Queue.php
+++ b/src/drivers/amqp/Queue.php
@@ -31,6 +31,8 @@ class Queue extends CliQueue
     public $queueName = 'queue';
     public $exchangeName = 'exchange';
     public $vhost = '/';
+    public $heartbeat = 0;
+    public $keepalive = false;
     /**
      * @var string command class name
      */
@@ -118,7 +120,24 @@ class Queue extends CliQueue
         if ($this->channel) {
             return;
         }
-        $this->connection = new AMQPStreamConnection($this->host, $this->port, $this->user, $this->password, $this->vhost);
+        $this->connection = new AMQPStreamConnection(
+            $this->host,
+            $this->port,
+            $this->user,
+            $this->password,
+            $this->vhost,
+            false,
+            'AMQPLAIN',
+            null,
+            'en_US',
+            3.0,
+            3.0,
+            null,
+            $this->keepalive,
+            $this->heartbeat,
+            0.0,
+            null
+        );
         $this->channel = $this->connection->channel();
         $this->channel->queue_declare($this->queueName, false, true, false, false);
         $this->channel->exchange_declare($this->exchangeName, 'direct', false, true, false);

--- a/src/drivers/amqp/Queue.php
+++ b/src/drivers/amqp/Queue.php
@@ -31,7 +31,15 @@ class Queue extends CliQueue
     public $queueName = 'queue';
     public $exchangeName = 'exchange';
     public $vhost = '/';
+    /**
+     * @var int The periods of time PHP pings the broker in order to prolong the connection timeout. In seconds.
+     * @since 2.3.1
+     */
     public $heartbeat = 0;
+    /**
+     * @var bool send keep-alive packets for a socket connection
+     * @since 2.3.1
+     */
     public $keepalive = false;
     /**
      * @var string command class name

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -110,6 +110,7 @@ class Queue extends CliQueue
     /**
      *
      * @var bool send keep-alive packets for a socket connection
+     * @since 2.3.1
      */
     public $keepalive;
     /**

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -108,6 +108,11 @@ class Queue extends CliQueue
      */
     public $persisted;
     /**
+     *
+     * @var bool send keep-alive packets for a socket connection
+     */
+    public $keepalive;
+    /**
      * The connection will be established as later as possible if set true.
      *
      * @var bool|null
@@ -351,6 +356,7 @@ class Queue extends CliQueue
             'connection_timeout' => $this->connectionTimeout,
             'heartbeat' => $this->heartbeat,
             'persisted' => $this->persisted,
+            'keepalive' => $this->keepalive,
             'lazy' => $this->lazy,
             'qos_global' => $this->qosGlobal,
             'qos_prefetch_size' => $this->qosPrefetchSize,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Если перед кластером rabbitmq стоит балансер (у нас это yandex cloud load balancer) то периодически consumers завершались с ошибкой "Connection timed out". Активация heartbeat режима, без переписывания обработчиков не поможет https://github.com/php-amqplib/RabbitMqBundle/issues/301

Нам помогло включение режима keepalive на стороне consumers.

Для возможности включения режима keepalive через конфиг и был создан данный PR
