### PR TITLE
ensure compatibility with symfony/process ^5.1 | ^5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.1 under development
 -----------------------
 
-- no changes in this release.
+- Bug #363,#371: Ensure compatibility with symfony/process >= 5.0 (HenryVolkmer)
 
 
 2.3.0 June 04, 2019

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.14",
-        "symfony/process": "^3.3||^4.0"
+        "symfony/process": "^5.0"
     },
     "require-dev": {
         "yiisoft/yii2-redis": "*",


### PR DESCRIPTION
- Bugfix: Process() Component expects first construct-param as array,String was given.
- bump symfony/process to Version 5.0

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | maybe yes
| Fixed issues  | #363 
