### PR TITLE
Fixed amqp-interop queue/listen signal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.1 under development
 -----------------------
 
-- no changes in this release.
+- Bug #380: Fixed amqp-interop queue/listen signal handling (tarinu)
 
 
 2.3.0 June 04, 2019

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -223,6 +223,28 @@ class Queue extends CliQueue
         Event::on(BaseApp::class, BaseApp::EVENT_AFTER_REQUEST, function () {
             $this->close();
         });
+
+        if (extension_loaded('pcntl') && PHP_MAJOR_VERSION >= 7) {
+            // https://github.com/php-amqplib/php-amqplib#unix-signals
+            $signals = [SIGTERM, SIGQUIT, SIGINT, SIGHUP];
+            
+            foreach($signals as $signal) {
+                $oldHandler = null;
+                // This got added in php 7.1 and might not exist on all supported versions
+                if(function_exists('pcntl_signal_get_handler')) {
+                    $oldHandler = pcntl_signal_get_handler($signal);
+                }
+
+                pcntl_signal($signal, static function ($signal) use ($oldHandler) {
+                    if($oldHandler && is_callable($oldHandler)) {
+                        $oldHandler($signal);
+                    }
+
+                    pcntl_signal($signal, SIG_DFL);
+                    posix_kill(posix_getpid(), $signal);
+                });
+            }
+        }
     }
 
     /**

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -228,15 +228,15 @@ class Queue extends CliQueue
             // https://github.com/php-amqplib/php-amqplib#unix-signals
             $signals = [SIGTERM, SIGQUIT, SIGINT, SIGHUP];
             
-            foreach($signals as $signal) {
+            foreach ($signals as $signal) {
                 $oldHandler = null;
                 // This got added in php 7.1 and might not exist on all supported versions
-                if(function_exists('pcntl_signal_get_handler')) {
+                if (function_exists('pcntl_signal_get_handler')) {
                     $oldHandler = pcntl_signal_get_handler($signal);
                 }
 
-                pcntl_signal($signal, static function ($signal) use ($oldHandler) {
-                    if($oldHandler && is_callable($oldHandler)) {
+                pcntl_signal ($signal, static function ($signal) use ($oldHandler) {
+                    if ($oldHandler && is_callable($oldHandler)) {
                         $oldHandler($signal);
                     }
 

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -235,7 +235,7 @@ class Queue extends CliQueue
                     $oldHandler = pcntl_signal_get_handler($signal);
                 }
 
-                pcntl_signal ($signal, static function ($signal) use ($oldHandler) {
+                pcntl_signal($signal, static function ($signal) use ($oldHandler) {
                     if ($oldHandler && is_callable($oldHandler)) {
                         $oldHandler($signal);
                     }

--- a/tests/drivers/CliTestCase.php
+++ b/tests/drivers/CliTestCase.php
@@ -38,6 +38,7 @@ abstract class CliTestCase extends TestCase
 
     /**
      * @param string $cmd
+     * @return Process
      */
     protected function startProcess($cmd)
     {
@@ -48,6 +49,7 @@ abstract class CliTestCase extends TestCase
             throw new ProcessFailedException($process);
         }
         $this->processes[] = $process;
+        return $process;
     }
 
     /**

--- a/tests/drivers/amqp_interop/QueueTest.php
+++ b/tests/drivers/amqp_interop/QueueTest.php
@@ -63,6 +63,28 @@ class QueueTest extends CliTestCase
     }
 
     /**
+     * @requires extension pcntl
+     */
+    public function testSignals()
+    {
+        $signals = [
+            1 => 129, // SIGHUP
+            2 => 130, // SIGINT
+            3 => 131, // SIGQUIT
+            15 => 143, // SIGTERM
+        ];
+
+        foreach ($signals as $signal => $exitCode) {
+            $process = $this->startProcess('php yii queue/listen');
+            $this->assertTrue($process->isRunning());
+            $process->signal($signal);
+            $process->wait();
+            $this->assertFalse($process->isRunning());
+            $this->assertEquals($exitCode, $process->getExitCode());
+        }
+    }
+
+    /**
      * @return Queue
      */
     protected function getQueue()


### PR DESCRIPTION
I couldn't get reverting the signal handler back to default working in PHP 5.6, so I made it to only register custom handlers in PHP 7+. This really shouldn't matter that much since the issue I was having should only appear on PHP 7.1+.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #379
