### PR TITLE
Fixed tests docs showing wrong filepath

### DIFF
--- a/docs/guide-ja/tests.md
+++ b/docs/guide-ja/tests.md
@@ -25,7 +25,7 @@ make test73
 `phpunit` にオプションを渡す必要があるとき (例えば一つのテストファイルだけを実行するとき) は、以下のコマンドを使います。
 ```bash
 docker-compose build --pull php73
-docker-compose run php73 vendor/bin/phpunit tests\\drivers\\sqs\\QueueTest /vagrant/yii2-queue/tests/drivers/sqs/QueueTest.php
+docker-compose run php73 vendor/bin/phpunit tests\\drivers\\sqs\\QueueTest /code/tests/drivers/sqs/QueueTest.php
 docker-compose down
 ```
 

--- a/docs/guide/tests.md
+++ b/docs/guide/tests.md
@@ -25,7 +25,7 @@ make test73
 If you need to pass options to `phpunit` use the following commands (for example, to run only one test file):
 ```bash
 docker-compose build --pull php73
-docker-compose run php73 vendor/bin/phpunit tests\\drivers\\sqs\\QueueTest /vagrant/yii2-queue/tests/drivers/sqs/QueueTest.php
+docker-compose run php73 vendor/bin/phpunit tests\\drivers\\sqs\\QueueTest /code/tests/drivers/sqs/QueueTest.php
 docker-compose down
 ```
 


### PR DESCRIPTION
Docker copies/mounts the files to `/code` instead of `/vagrant/yii2-queue`. This fixes the documentation mistake.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | they should
| Fixed issues  | -
