### PR TITLE
Изменение модификатора доступа

### DIFF
--- a/src/drivers/db/Queue.php
+++ b/src/drivers/db/Queue.php
@@ -236,7 +236,7 @@ class Queue extends CliQueue
     /**
      * Moves expired messages into waiting list.
      */
-    private function moveExpired()
+    protected function moveExpired()
     {
         if ($this->reserveTime !== time()) {
             $this->reserveTime = time();
@@ -249,5 +249,5 @@ class Queue extends CliQueue
         }
     }
 
-    private $reserveTime;
+    protected $reserveTime;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Breaks BC?    | no

Причина изменения. Проблема в том, что если джоба фейлится по любой причине, следующая попытка будет только через TTR секунд.  К примеру, у меня TTR = 20 минут, и если джоба зафейлится через 10 секунд после старта, то мне придется ждать еще 19 минут 50 сек до следующей попытки. Я наследовался от класса \yii\queue\db\Queue  хотел бы ввести параметр $retryIn, на основе которого принималось бы решение стоит ли перезапускать джобу раньше или нет.  Но по скольку у данного метода текущий модификатор private, то мне придется еще копипастить местод reserve(), чего делать бы не хотелось