### PR TITLE
change queue migration console command

### DIFF
--- a/docs/guide/driver-db.md
+++ b/docs/guide/driver-db.md
@@ -89,7 +89,7 @@ To add migrations to your application, edit the console config file to configure
 ```php
 'controllerMap' => [
     // ...
-    'migrate' => [
+    'migrate-queue' => [
         'class' => 'yii\console\controllers\MigrateController',
         'migrationPath' => null,
         'migrationNamespaces' => [
@@ -100,10 +100,10 @@ To add migrations to your application, edit the console config file to configure
 ],
 ```
 
-Then issue the `migrate/up` command:
+Then issue the `migrate-queue/up` command:
 
 ```sh
-yii migrate/up
+yii migrate-queue/up
 ```
 
 Console


### PR DESCRIPTION
if we setup those migration command to queue, then all the migration in the project will be created under queue directory, so i think it's nice to separate the console command like  in this change

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

Just the documents changes
