### PR TITLE
Pass the path to a php.ini file to a child process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.2 under development
 -----------------------
 
-- no changes in this release.
+- Enh: Added path to an `.ini` file to a child process (werdender)
 
 
 2.3.1 December 23, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.2 under development
 -----------------------
 
-- Enh: Added path to an `.ini` file to a child process (werdender)
+- Enh #412: Added path to an `.ini` file to a child process (werdender)
 
 
 2.3.1 December 23, 2020

--- a/src/cli/Command.php
+++ b/src/cli/Command.php
@@ -162,18 +162,23 @@ abstract class Command extends Controller
      */
     protected function handleMessage($id, $message, $ttr, $attempt)
     {
-        // Child process command: php -c <PATH_TO_INI_FILE> yii queue/exec "id" "ttr" "attempt" "pid"
+        // Child process command: php [-c <PATH_TO_INI_FILE>] yii queue/exec "id" "ttr" "attempt" "pid"
         $cmd = [
-            $this->phpBinary,
-            '-c',
-            get_cfg_var('cfg_file_path'),
-            $_SERVER['SCRIPT_FILENAME'],
-            $this->uniqueId . '/exec',
-            $id,
-            $ttr,
-            $attempt,
-            $this->queue->getWorkerPid() ?: 0,
+            $this->phpBinary
         ];
+
+        $config = get_cfg_var('cfg_file_path');
+        if(is_string($config)) {
+            $cmd[] = '-c';
+            $cmd[] = $config;
+        }
+        
+        $cmd[] = $_SERVER['SCRIPT_FILENAME'];
+        $cmd[] = $this->uniqueId . '/exec';
+        $cmd[] = $id;
+        $cmd[] = $ttr;
+        $cmd[] = $attempt;
+        $cmd[] = $this->queue->getWorkerPid() ?: 0;
 
         foreach ($this->getPassedOptions() as $name) {
             if (in_array($name, $this->options('exec'), true)) {

--- a/src/cli/Command.php
+++ b/src/cli/Command.php
@@ -168,7 +168,7 @@ abstract class Command extends Controller
         ];
 
         $config = get_cfg_var('cfg_file_path');
-        if(is_string($config)) {
+        if (is_string($config)) {
             $cmd[] = '-c';
             $cmd[] = $config;
         }

--- a/src/cli/Command.php
+++ b/src/cli/Command.php
@@ -162,9 +162,11 @@ abstract class Command extends Controller
      */
     protected function handleMessage($id, $message, $ttr, $attempt)
     {
-        // Child process command: php yii queue/exec "id" "ttr" "attempt" "pid"
+        // Child process command: php -c <PATH_TO_INI_FILE> yii queue/exec "id" "ttr" "attempt" "pid"
         $cmd = [
             $this->phpBinary,
+            '-c',
+            get_cfg_var('cfg_file_path'),
             $_SERVER['SCRIPT_FILENAME'],
             $this->uniqueId . '/exec',
             $id,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Description:
The problem is the child process ignores path to a php.ini file which was defined in supervisor tools like systemd. For example, if you have configured the `pdo_mysql.default_socket` parameter (which must be different for different sites) in an ini file, and want to run the queue in systemd unit file like this:
`ExecStart=/usr/bin/php -c /var/www/somesite/php.ini /var/www/somesite/current/yii queue/listen`
the passed -c parameter will be ignored by a child process and it will b still try using xx/cli/php.ini file and the wrong socket.

So, I've added the -c parameter to the child process.