### PR TITLE
Add function_exists() checks for PCNTL functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.2 under development
 -----------------------
 
-- no changes in this release.
+- Bug #414: Fixed PHP errors when PCNTL functions were disallowed (brandonkelly)
 
 
 2.3.1 December 23, 2020

--- a/src/cli/SignalLoop.php
+++ b/src/cli/SignalLoop.php
@@ -69,7 +69,7 @@ class SignalLoop extends BaseObject implements LoopInterface
     public function init()
     {
         parent::init();
-        if (extension_loaded('pcntl')) {
+        if (extension_loaded('pcntl') && function_exists('pcntl_signal')) {
             foreach ($this->exitSignals as $signal) {
                 pcntl_signal($signal, function () {
                     self::$exit = true;
@@ -95,7 +95,7 @@ class SignalLoop extends BaseObject implements LoopInterface
      */
     public function canContinue()
     {
-        if (extension_loaded('pcntl')) {
+        if (extension_loaded('pcntl') && function_exists('pcntl_signal_dispatch')) {
             pcntl_signal_dispatch();
             // Wait for resume signal until loop is suspended
             while (self::$pause && !self::$exit) {

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -224,7 +224,7 @@ class Queue extends CliQueue
             $this->close();
         });
 
-        if (extension_loaded('pcntl') && PHP_MAJOR_VERSION >= 7) {
+        if (extension_loaded('pcntl') && function_exists('pcntl_signal') && PHP_MAJOR_VERSION >= 7) {
             // https://github.com/php-amqplib/php-amqplib#unix-signals
             $signals = [SIGTERM, SIGQUIT, SIGINT, SIGHUP];
             


### PR DESCRIPTION
We have a couple customers running Craft CMS on hosts that have the PCNTL extension installed, but its functions are listed in `disabled_functions`, so they get PHP errors when running the queue.

This PR enhances the `extension_loaded('pcntl')` checks with specific checks to see if its functions also exist. We’ve verified that it fixes the PHP errors.


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
