### PR TITLE
Fix for MySQL job queue size (issue #257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.3 under development
 -----------------------
 
-- Enh $257: Increase MySQL db job size to more than 65KB (lourdas)
+- Enh #257: Increase MySQL db job size to more than 65KB (lourdas)
 - Enh #430: Added configurable AMQP Exchange type (s1lver)
 - Enh #394: Added stack trace on error in verbose mode (germanow)
 - Enh #435: Added the ability to set optional arguments for the AMQP queue (s1lver)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.3 under development
 -----------------------
 
+- Enh $257: Increase MySQL db job size to more than 65KB (lourdas)
 - Enh #430: Added configurable AMQP Exchange type (s1lver)
 - Enh #394: Added stack trace on error in verbose mode (germanow)
 - Enh #435: Added the ability to set optional arguments for the AMQP queue (s1lver)

--- a/docs/guide/driver-db.md
+++ b/docs/guide/driver-db.md
@@ -41,7 +41,7 @@ MySQL:
 CREATE TABLE `queue` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `channel` varchar(255) NOT NULL,
-  `job` blob NOT NULL,
+  `job` longblob NOT NULL,
   `pushed_at` int(11) NOT NULL,
   `ttr` int(11) NOT NULL,
   `delay` int(11) NOT NULL DEFAULT 0,

--- a/src/drivers/db/migrations/M211218163000JobQueueSize.php
+++ b/src/drivers/db/migrations/M211218163000JobQueueSize.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\queue\db\migrations;
+
+use yii\db\Migration;
+
+/**
+ * Example of migration for queue message storage.
+ *
+ * @author Roman Zhuravlev <zhuravljov@gmail.com>
+ */
+class M211218163000JobQueueSize extends Migration
+{
+    public $tableName = '{{%queue}}';
+
+
+    public function up()
+    {
+        if ($this->db->driverName === 'mysql') {
+            $this->alterColumn('{{%queue}}', 'job', 'LONGBLOB NOT NULL');
+        }
+    }
+
+    public function down()
+    {
+        if ($this->db->driverName === 'mysql') {
+            $this->alterColumn('{{%queue}}', 'job', $this->binary()->notNull());
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #257

The fix mainly targets MySQL/MariaDB, AFAIK, PostgreSQL is not affected. I don't know about other databases though.