### PR TITLE
Force index for reserved_at field on db queue driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.4 under development
 -----------------------
 
-- no changes in this release.
+- Enh #449: Force db to use the index on the `reserved_at` column to unlock unfinished tasks in DB driver (erickskrauch)
 
 
 2.3.3 December 30, 2021

--- a/src/drivers/db/Queue.php
+++ b/src/drivers/db/Queue.php
@@ -243,7 +243,9 @@ class Queue extends CliQueue
             $this->db->createCommand()->update(
                 $this->tableName,
                 ['reserved_at' => null],
-                '[[reserved_at]] < :time - [[ttr]] and [[done_at]] is null',
+                // `reserved_at IS NOT NULL` forces db to use index on column,
+                // otherwise a full scan of the table will be performed
+                '[[reserved_at]] is not null and [[reserved_at]] < :time - [[ttr]] and [[done_at]] is null',
                 [':time' => $this->reserveTime]
             )->execute();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | I didn't create 🙈

In the production environment, we encountered a situation where the worker didn't work for a while, but jobs kept being pushed to the queue. By the time the problem was fixed, there were already over 300k jobs in queue. We started the queue, but it was very slow. With the help of the profiler, we were able to discover that the request to unblock unfinished tasks was taking the longest time. And being inside the mutex lock, it didn't allow us to parallelize the tasks. After investigating the behavior of the code in the MariaDB database, I came up with the solution to add a simple pre-filter that would force the database to use the filter first, and then apply more complex filters on the rest of the set.

We tested this solution in production and now everything works for large data volumes.