### PR TITLE
Updated closures serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.5 under development
 -----------------------
 
-- Enh: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs.
+- Enh: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs (mp1509).
 
 
 2.3.4 March 31, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.5 under development
 -----------------------
 
-- Enh #457: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs (mp1509)
+- Enh #459: Added the ability to sets of flags for the AMQP queue and exchange (s1lver)
 
 
 2.3.4 March 31, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii2 Queue Extension Change Log
 -----------------------
 
 - Enh #459: Added the ability to sets of flags for the AMQP queue and exchange (s1lver)
+- Enh #457: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs.
 
 
 2.3.4 March 31, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii2 Queue Extension Change Log
 -----------------------
 
 - Enh #459: Added the ability to sets of flags for the AMQP queue and exchange (s1lver)
-- Enh #457: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs.
+- Enh #457: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs (mp1509).
 
 
 2.3.4 March 31, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.5 under development
 -----------------------
 
-- no changes in this release.
+- Enh: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs.
 
 
 2.3.4 March 31, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii2 Queue Extension Change Log
 2.3.5 under development
 -----------------------
 
-- Enh: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs (mp1509).
+- Enh #457: Upgraded `jeremeamia/superclosure` library to `opis/closure`, adding the possibility to have closures as properties of the jobs (mp1509)
 
 
 2.3.4 March 31, 2022

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php-amqplib/php-amqplib": "*",
         "enqueue/amqp-lib": "^0.8||^0.9.10",
         "pda/pheanstalk": "v3.*",
-        "jeremeamia/superclosure": "*",
+        "opis/closure": "*",
         "yiisoft/yii2-debug": "*",
         "yiisoft/yii2-gii": "*",
         "phpunit/phpunit": "~4.4",

--- a/composer.json
+++ b/composer.json
@@ -72,5 +72,10 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
-    ]
+    ],
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,11 @@
             "tests\\": "tests"
         }
     },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.0",
         "yiisoft/yii2": "~2.0.14",
-        "symfony/process": "^3.3||^4.0||^5.0"
+        "symfony/process": "^3.3||^4.0||^5.0||^6.0"
     },
     "require-dev": {
         "yiisoft/yii2-redis": "*",

--- a/src/closure/Behavior.php
+++ b/src/closure/Behavior.php
@@ -7,7 +7,7 @@
 
 namespace yii\queue\closure;
 
-use SuperClosure\Serializer;
+use function Opis\Closure\serialize as opis_serialize;
 use yii\queue\PushEvent;
 use yii\queue\Queue;
 
@@ -50,11 +50,8 @@ class Behavior extends \yii\base\Behavior
      */
     public function beforePush(PushEvent $event)
     {
-        if ($event->job instanceof \Closure) {
-            $serializer = new Serializer();
-            $serialized = $serializer->serialize($event->job);
-            $event->job = new Job();
-            $event->job->serialized = $serialized;
-        }
+        $serialized = opis_serialize($event->job);
+        $event->job = new Job();
+        $event->job->serialized = $serialized;
     }
 }

--- a/src/closure/Job.php
+++ b/src/closure/Job.php
@@ -7,7 +7,7 @@
 
 namespace yii\queue\closure;
 
-use SuperClosure\Serializer;
+use function Opis\Closure\unserialize as opis_unserialize;
 use yii\queue\JobInterface;
 
 /**
@@ -29,8 +29,10 @@ class Job implements JobInterface
      */
     public function execute($queue)
     {
-        $serializer = new Serializer();
-        $closure = $serializer->unserialize($this->serialized);
-        return $closure();
+        $unserialized = opis_unserialize($this->serialized);
+        if ($unserialized instanceof \Closure) {
+            return $unserialized();
+        }
+        return $unserialized->execute($queue);
     }
 }

--- a/src/drivers/amqp_interop/Queue.php
+++ b/src/drivers/amqp_interop/Queue.php
@@ -15,6 +15,7 @@ use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Interop\Amqp\AmqpConnectionFactory;
 use Interop\Amqp\AmqpConsumer;
 use Interop\Amqp\AmqpContext;
+use Interop\Amqp\AmqpDestination;
 use Interop\Amqp\AmqpMessage;
 use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\AmqpTopic;
@@ -183,6 +184,13 @@ class Queue extends CliQueue
      */
     public $queueOptionalArguments = [];
     /**
+     * Set of flags for the queue
+     * @var int
+     * @since 2.3.5
+     * @see AmqpDestination
+     */
+    public $queueFlags = AmqpQueue::FLAG_DURABLE;
+    /**
      * The exchange used to publish messages to.
      *
      * @var string
@@ -194,6 +202,13 @@ class Queue extends CliQueue
      * @since 2.3.3
      */
     public $exchangeType = AmqpTopic::TYPE_DIRECT;
+    /**
+     * Set of flags for the exchange
+     * @var int
+     * @since 2.3.5
+     * @see AmqpDestination
+     */
+    public $exchangeFlags = AmqpTopic::FLAG_DURABLE;
     /**
      * Routing key for publishing messages. Default is NULL.
      *
@@ -435,7 +450,7 @@ class Queue extends CliQueue
         }
 
         $queue = $this->context->createQueue($this->queueName);
-        $queue->addFlag(AmqpQueue::FLAG_DURABLE);
+        $queue->setFlags($this->queueFlags);
         $queue->setArguments(array_merge(
             ['x-max-priority' => $this->maxPriority],
             $this->queueOptionalArguments
@@ -444,7 +459,7 @@ class Queue extends CliQueue
 
         $topic = $this->context->createTopic($this->exchangeName);
         $topic->setType($this->exchangeType);
-        $topic->addFlag(AmqpTopic::FLAG_DURABLE);
+        $topic->setFlags($this->exchangeFlags);
         $this->context->declareTopic($topic);
 
         $this->context->bind(new AmqpBind($queue, $topic, $this->routingKey));

--- a/tests/closure/ClosureJob.php
+++ b/tests/closure/ClosureJob.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace tests\closure;
+
+use yii\base\BaseObject;
+use yii\queue\JobInterface;
+
+/**
+ * Closure Job.
+ *
+ * @author Yetopen S.r.l. <info@yetopen.com>
+ */
+class ClosureJob extends BaseObject implements JobInterface
+{
+    /**
+     * @var \Closure
+     */
+    public $closure;
+
+    public function execute($queue)
+    {
+        call_user_func($this->closure);
+    }
+}

--- a/tests/closure/ClosureTest.php
+++ b/tests/closure/ClosureTest.php
@@ -39,6 +39,32 @@ class ClosureTest extends TestCase
         $this->assertFileExists($fileName);
     }
 
+    public function testPush3()
+    {
+        $job = new ClosureJob([
+            'closure' => function () {
+                $fileName = Yii::getAlias('@runtime/job-3.lock');
+                file_put_contents($fileName, '');
+            }
+        ]);
+        $this->getQueue()->push($job);
+        $this->getQueue()->run();
+        $this->assertFileExists(Yii::getAlias('@runtime/job-3.lock'));
+    }
+
+    public function testPush4()
+    {
+        $fileName = Yii::getAlias('@runtime/job-4.lock');
+        $job = new ClosureJob([
+            'closure' => function () use ($fileName) {
+                file_put_contents($fileName, '');
+            }
+        ]);
+        $this->getQueue()->push($job);
+        $this->getQueue()->run();
+        $this->assertFileExists($fileName);
+    }
+
     /**
      * @return Queue
      */


### PR DESCRIPTION
Made the following changes:
1. Upgraded [jeremeamia/superclosure](https://github.com/jeremeamia/super_closure) passing to new library [opis/closure](https://github.com/opis/closure)
2. Updated `yii\queue\closure\Behavior` and `yii\queue\closure\Job` to work with the new library without breaking previous set-ups
3. Added possibility to serialize objects containing closures in properties.
4. Implemented tests cases to check point 3

| Q             | A
| ------------- | ---
| Is bugfix?    |  ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | ❌
| Tests Passed | ✔️
