### PR TITLE
fix $id type

### DIFF
--- a/src/drivers/file/Queue.php
+++ b/src/drivers/file/Queue.php
@@ -120,7 +120,7 @@ class Queue extends CliQueue
     /**
      * Removes a job by ID.
      *
-     * @param int $id of a job
+     * @param string $id of a job
      * @return bool
      * @since 2.0.1
      */


### PR DESCRIPTION

in other methods the type on $id is string

https://github.com/yiisoft/yii2-queue/blob/master/src/cli/Queue.php#L151
https://github.com/yiisoft/yii2-queue/blob/5a30082b1595e234a8fa5afc591e4f78c5e5de29/src/Queue.php#L328
https://github.com/yiisoft/yii2-queue/blob/5a30082b1595e234a8fa5afc591e4f78c5e5de29/src/Queue.php#L301
https://github.com/yiisoft/yii2-queue/blob/5a30082b1595e234a8fa5afc591e4f78c5e5de29/src/Queue.php#L222
and other

