### PR TITLE
Added `SIGQUIT` to SignalLoop::$exitSignals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii2 Queue Extension Change Log
 
 - Enh #372: Add ability to configure keepalive and heartbeat for AMQP and AMQP interop (vyachin)
 - Enh #464: Delete property `maxPriority` (skolkin-worker)
+- Enh #486: `SignalLoop::$exitSignals` now includes `SIGQUIT` (rhertogh)
 
 
 2.3.5 November 18, 2022

--- a/src/cli/SignalLoop.php
+++ b/src/cli/SignalLoop.php
@@ -22,6 +22,7 @@ class SignalLoop extends BaseObject implements LoopInterface
      */
     public $exitSignals = [
         15, // SIGTERM
+        3,  // SIGQUIT
         2,  // SIGINT
         1,  // SIGHUP
     ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Include SIGQUIT in the exit signals.