### PR TITLE
Pass TTR StringValue as a string

### DIFF
--- a/src/drivers/sqs/Queue.php
+++ b/src/drivers/sqs/Queue.php
@@ -200,7 +200,7 @@ class Queue extends CliQueue
             'MessageAttributes' => [
                 'TTR' => [
                     'DataType' => 'Number',
-                    'StringValue' => $ttr,
+                    'StringValue' => (string) $ttr,
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️

A recent AWS SDK release throws an error if a `StringValue` value is passed as a non-string:

```
[web.ERROR] [yii\base\ErrorException:512] The provided type for `MessageAttributes -> TTR -> StringValue` value was `integer`. The modeled type is `string`.
```