### PR TITLE
Enhancement: Ensure messages are consumed at least once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii2 Queue Extension Change Log
 
 2.3.8 under development
 -----------------------
-
+- Enh: Ensure Redis driver messages are consumed at least once (soul11201)
 - Bug #522: Fix SQS driver type error with custom value passed to `queue/listen` (flaviovs)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Yii2 Queue Extension Change Log
 
 2.3.8 under development
 -----------------------
-- Enh: Ensure Redis driver messages are consumed at least once (soul11201)
+- Enh #516: Ensure Redis driver messages are consumed at least once (soul11201)
 - Bug #522: Fix SQS driver type error with custom value passed to `queue/listen` (flaviovs)
 
 

--- a/src/drivers/redis/Queue.php
+++ b/src/drivers/redis/Queue.php
@@ -170,10 +170,10 @@ class Queue extends CliQueue implements StatisticsProviderInterface
     {
         $now = time();
         if ($expired = $this->redis->zrevrangebyscore($from, $now, '-inf')) {
-            $this->redis->zremrangebyscore($from, '-inf', $now);
             foreach ($expired as $id) {
                 $this->redis->rpush("$this->channel.waiting", $id);
             }
+            $this->redis->zremrangebyscore($from, '-inf', $now);
         }
     }
 

--- a/tests/drivers/redis/QueueTest.php
+++ b/tests/drivers/redis/QueueTest.php
@@ -171,7 +171,7 @@ class QueueTest extends CliTestCase
         $fault();
 
         //make the redlock invalid after 1s
-        sleep(1);
+        sleep(2);
         $this->getQueue()->run(false);
         $this->assertEquals(1, $msgCount);
     }

--- a/tests/drivers/redis/QueueTest.php
+++ b/tests/drivers/redis/QueueTest.php
@@ -154,7 +154,7 @@ class QueueTest extends CliTestCase
         $this->getQueue()->delay(1)->push($job);
         // Expect a single message to be received.
         $messageCount = 0;
-        $this->getQueue()->messageHandler = function () use(&$msgCount) {
+        $this->getQueue()->messageHandler = function () use(&$messageCount) {
             $messageCount++;
         };
 
@@ -182,7 +182,7 @@ class QueueTest extends CliTestCase
             $queue->redis = $old;
         }
 
-        // Ensure the redlock is invalid after 1s.
+        // Ensure the red lock is invalid. The red lock is valid for 1s.
         sleep(2);
         $this->getQueue()->run(false);
         $this->assertEquals(1, $messageCount);

--- a/tests/drivers/redis/QueueTest.php
+++ b/tests/drivers/redis/QueueTest.php
@@ -144,9 +144,9 @@ class QueueTest extends CliTestCase
         $job = $this->createSimpleJob();
         $this->getQueue()->delay(1)->push($job);
         //expect 1 msg should be recv
-        $this->getQueue()->messageHandler = function () {
-            var_dump(func_get_args());
-            $this->assertEquals(1, $this->getQueue()->getStatisticsProvider()->getReservedCount());
+        $msgCount = 0;
+        $this->getQueue()->messageHandler = function () use(&$msgCount) {
+            $msgCount++;
         };
 
         $fault = function () {
@@ -171,5 +171,6 @@ class QueueTest extends CliTestCase
         $fault();
 
         $this->getQueue()->run(false);
+        $this->assertEquals(1, $msgCount);
     }
 }

--- a/tests/drivers/redis/QueueTest.php
+++ b/tests/drivers/redis/QueueTest.php
@@ -170,6 +170,8 @@ class QueueTest extends CliTestCase
         };
         $fault();
 
+        //make the redlock invalid after 1s
+        sleep(1);
         $this->getQueue()->run(false);
         $this->assertEquals(1, $msgCount);
     }

--- a/tests/drivers/redis/RedisCrashMock.php
+++ b/tests/drivers/redis/RedisCrashMock.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace tests\drivers\redis;
+
+use yii\redis\Connection;
+
+class RedisCrashMock extends Connection
+{
+    function rpush($key, $value)
+    {
+        throw new \Exception('panic');
+    }
+}

--- a/tests/drivers/redis/RedisCrashMock.php
+++ b/tests/drivers/redis/RedisCrashMock.php
@@ -1,13 +1,17 @@
 <?php
-
 namespace tests\drivers\redis;
 
 use yii\redis\Connection;
 
 class RedisCrashMock extends Connection
 {
-    function rpush($key, $value)
+    public $crashOnCommand;
+
+    public function executeCommand($name, $params = [])
     {
-        throw new \Exception('panic');
+        if ($name === $this->crashOnCommand) {
+            throw new \RuntimeException('Simulated Redis crash');
+        }
+        return parent::executeCommand($name, $params);
     }
 }


### PR DESCRIPTION
The host may crashed before`rpush` was executed

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
