### PR TITLE
Fix type hint for previous parameter in `InvalidJobException` class constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Yii2 Queue Extension Change Log
 - Bug #522: Fix SQS driver type error with custom value passed to `queue/listen` (flaviovs)
 - Bug #528: Prevent multiple execution of aborted jobs (luke-)
 - Enh #493: Pass environment variables to sub-processes (mgrechanik)
-- Bug #538: Fix type hint for previous parameter in `InvalidJobException` class constructor (terabytesoftw)
+- Bug #538: Fix type hint for previous parameter in `InvalidJobException` class constructor in PHP `8.4` (implicitly marking parameter nullable) (terabytesoftw)
 
 2.3.7 April 29, 2024
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii2 Queue Extension Change Log
 - Bug #522: Fix SQS driver type error with custom value passed to `queue/listen` (flaviovs)
 - Bug #528: Prevent multiple execution of aborted jobs (luke-)
 - Enh #493: Pass environment variables to sub-processes (mgrechanik)
+- Bug #538: Fix type hint for previous parameter in `InvalidJobException` class constructor (terabytesoftw)
 
 2.3.7 April 29, 2024
 --------------------

--- a/src/InvalidJobException.php
+++ b/src/InvalidJobException.php
@@ -31,7 +31,7 @@ class InvalidJobException extends \Exception
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct($serialized, $message = '', $code = 0, Throwable $previous = null)
+    public function __construct($serialized, $message = '', $code = 0, $previous = null)
     {
         $this->serialized = $serialized;
         parent::__construct($message, $code, $previous);

--- a/tests/docker/php/7.1/Dockerfile
+++ b/tests/docker/php/7.1/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:7.1-cli
 
-RUN apt-get update \
+RUN echo "deb http://archive.debian.org/debian buster main contrib non-free" > /etc/apt/sources.list \
+    && echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" >> /etc/apt/sources.list \
+    && apt-get update --allow-releaseinfo-change \
     && apt-get install -y unzip curl zlib1g-dev libicu-dev libpq-dev libgearman-dev
 
 RUN docker-php-ext-install zip pcntl bcmath pdo_mysql intl pdo_pgsql

--- a/tests/docker/php/7.2/Dockerfile
+++ b/tests/docker/php/7.2/Dockerfile
@@ -1,7 +1,9 @@
 FROM php:7.2-cli
 
-RUN apt-get update \
-    && apt-get install -y unzip libbz2-dev curl zlib1g-dev libicu-dev libpq-dev libgearman-dev
+RUN echo "deb http://archive.debian.org/debian buster main contrib non-free" > /etc/apt/sources.list \
+    && echo "deb http://archive.debian.org/debian-security buster/updates main contrib non-free" >> /etc/apt/sources.list \
+    && apt-get update --allow-releaseinfo-change \
+    && apt-get install -y unzip curl zlib1g-dev libicu-dev libpq-dev libgearman-dev
 
 RUN docker-php-ext-install zip pcntl bcmath pdo_mysql intl pdo_pgsql
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
