### PR TITLE
Fix #564: Allow `symfony/process` `^8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii2 Queue Extension Change Log
 - Enh #503: The `opis/closure` package did not support PHP 8.1 and was replaced by the `laravel/serializable-closure` package (@s1lver)
 - Enh #544: Applying Yii2 coding standards (@s1lver)
 - Bug #563: Fix `@property` annotations in `InfoAction` and `Queue` drivers (mspirkov)
+- Enh #564: Allow `symfony/process` `^8.0` (lukascernydis)
 
 2.3.8 January 08, 2026
 ----------------------

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.3",
         "yiisoft/yii2": "~2.0.54",
-        "symfony/process": "^7.0",
+        "symfony/process": "^7.0||^8.0",
         "laravel/serializable-closure": "^v2.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
The Process API surface this package uses (constructor signature, Process::ERR, ProcessFailedException, RuntimeException) is unchanged between symfony/process 7.x and 8.x, so this is a plain constraint widening rather than a compatibility fix.

This unblocks installing yii2-queue alongside packages that now require symfony/process ^8.0 (e.g. current pestphp/pest and brianium/paratest).

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | none
